### PR TITLE
fix(search): 扩展集兜底无条件触发——修「观夏」搜不到

### DIFF
--- a/src/components/library/SearchAdd.tsx
+++ b/src/components/library/SearchAdd.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "@/components/AppProvider";
 import { useStore } from "@/lib/store";
-import { buildSearch, loadExtSearch, fetchExtPerfume, type ExtIndexEntry } from "@/lib/perfumes";
+import { buildSearch, loadExtSearch, fetchExtPerfume, selectExtHits, type ExtIndexEntry } from "@/lib/perfumes";
 import { nameParts } from "@/lib/format";
 import { ManualAdd } from "@/components/library/ManualAdd";
 import type { Perfume } from "@/lib/types";
@@ -41,21 +41,15 @@ export function SearchAdd() {
     const hits = ms.search(q.trim()).slice(0, 8);
     const main = hits.map((h) => byId.get(h.id as number)).filter(Boolean) as Perfume[];
     setResults(main);
-    // 主目录命中不足 → 懒加载扩展索引兜底（首次约几百 KB，此后走缓存）
-    if (main.length < 3) {
-      const query = q.trim();
-      loadExtSearch().then((ext) => {
-        if (!ext || qRef.current !== query) return; // 过期查询丢弃
-        const mainIds = new Set(main.map((p) => p.id));
-        const found = ext
-          .search(query)
-          .filter((h) => !mainIds.has(h.i as number))
-          .slice(0, 5) as unknown as ExtIndexEntry[];
-        setExtHits(found);
-      });
-    } else {
-      setExtHits([]);
-    }
+    // 扩展集搜索无条件跑（索引懒加载一次，此后走缓存）——不能按"主目录命中不足"触发：
+    // 主目录 OR+fuzzy 的单字垃圾命中会凑数，「观夏」曾因此彻底搜不到。取舍见 selectExtHits。
+    const query = q.trim();
+    loadExtSearch().then((ext) => {
+      if (!ext || qRef.current !== query) return; // 过期查询丢弃
+      const mainIds = new Set(main.map((p) => p.id));
+      const all = ext.search(query).filter((h) => !mainIds.has(h.i as number)) as unknown as ExtIndexEntry[];
+      setExtHits(selectExtHits(all, query, main.length));
+    });
   }, [q, ms, byId]);
 
   useEffect(() => {

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -360,6 +360,27 @@ test("「用力过猛」组合：甜重/浓白花 × 强扩散 × 通勤，压�
   assert.ok(computeRisks(loudSweet, ctx).some((r) => r.includes("用力过猛")));
 });
 
+test("selectExtHits：强命中无视主目录垃圾计数（「观夏」回归）；无强命中时才看主目录贫瘠度", async () => {
+  const { selectExtHits } = await import("./perfumes");
+  const guanxia = [
+    { i: 1, n: "Triple Tea 三重茶", b: "To Summer | 观夏", p: 261 },
+    { i: 2, n: "Cedarwood 昆仑煮雪", b: "To Summer | 观夏", p: 80 },
+  ];
+  const junk = [
+    { i: 9, n: "Random Summer", b: "Nobody", p: 10 },
+    { i: 10, n: "Another", b: "Nobody", p: 9 },
+  ];
+  // 回归核心：主目录被「夏」字垃圾命中凑到 7 条时，观夏的强命中仍必须给出
+  const picked = selectExtHits([...junk, ...guanxia], "观夏", 7);
+  assert.deepEqual(picked.map((e) => e.i), [1, 2]);
+  // 多词段：每段都得是连续子串
+  assert.deepEqual(selectExtHits([...junk, ...guanxia], "观夏 三重茶", 7).map((e) => e.i), [1]);
+  // 无强命中 + 主目录已有像样结果 → 不放噪音
+  assert.deepEqual(selectExtHits(junk, "蓝风铃", 5), []);
+  // 无强命中 + 主目录贫瘠 → 放出模糊命中兜底（拼写误差/英文场景）
+  assert.equal(selectExtHits(junk, "sumer", 0).length, 2);
+});
+
 test("riskNote：场景解析的社交风险以受控字段进入风险列表", () => {
   const p = mk({ accords: acc([["citrus", 60]]) });
   const risks = computeRisks(p, C({ occasion: "formal", feel: "mild", tempC: 20, riskNote: "婚礼焦点是新人，不宜喧宾夺主" }));

--- a/src/lib/perfumes.ts
+++ b/src/lib/perfumes.ts
@@ -103,6 +103,27 @@ export function loadExtSearch(): Promise<MiniSearch<ExtIndexEntry> | null> {
   return extIndexPromise;
 }
 
+// 扩展集命中的取舍（纯函数，可单测）。教训（「观夏」搜不到）：主目录的 OR+fuzzy 会用无关的
+// 单字命中凑数——搜「观夏」时「夏」字垃圾命中 7 条，若按"主目录不足 3 条才兜底"，扩展集永远轮不到。
+// 因此扩展搜索无条件跑，取舍放在这里：
+// 1. 强命中优先：查询的每个词段都是条目串（名+品牌+中文）的连续子串 → 这是用户要找的，直接给；
+// 2. 没有强命中时，只在主目录确实贫瘠（<3 条）才放出模糊命中——避免好查询下面挂一排噪音。
+export function selectExtHits<T extends ExtIndexEntry>(
+  hits: T[],
+  query: string,
+  mainCount: number,
+  limit = 5
+): T[] {
+  const segs = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (segs.length === 0) return [];
+  const strong = hits.filter((e) => {
+    const hay = `${e.n} ${e.b} ${e.z ?? ""}`.toLowerCase();
+    return segs.every((s) => hay.includes(s));
+  });
+  if (strong.length > 0) return strong.slice(0, limit);
+  return mainCount < 3 ? hits.slice(0, limit) : [];
+}
+
 export async function fetchExtPerfume(id: number): Promise<Perfume | null> {
   const shardNo = ((id % 64) + 64) % 64;
   let shard = extShardCache.get(shardNo) ?? null;


### PR DESCRIPTION
线上 bug：搜「观夏」无结果。

**根因**（本地复现实锤）：主目录 OR+fuzzy 用无关单字命中凑数——「夏」字垃圾命中 7 条（诺亚/爱慕/露露…全部无关），而扩展集兜底的触发条件是「主目录 <3 条」，永远不成立 → 观夏 23 款彻底搜不出。扩展索引本身完全正常（直接搜命中 86 条、前 5 全对）。

**修复**：扩展集搜索无条件跑，取舍下沉到纯函数 `selectExtHits`——强命中（每个词段都是连续子串）无视主目录计数直接给；无强命中才看主目录贫瘠度，避免好查询下面挂一排噪音。

**验证**：真实数据 E2E——「观夏 / 闻献 / 昆仑煮雪 / 观夏 三重茶」全部返回正确且全相关结果；37/37 用例、0 lint error、构建通过；线上 /data/ext-index.json 可达性已确认（200）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)