### PR TITLE
fix(search): 统一搜索榜单——文本档位 × 主流度排序，取消「更多结果」区隔

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "node --import tsx --test src/lib/engine.test.ts src/lib/journal.test.ts",
+    "test": "node --import tsx --test src/lib/engine.test.ts src/lib/journal.test.ts src/lib/search.test.ts",
     "build:data": "node scripts/build.mjs",
     "build:ext": "node scripts/build-ext.mjs",
     "extract:terms": "node scripts/extract-terms.mjs",

--- a/src/components/library/SearchAdd.tsx
+++ b/src/components/library/SearchAdd.tsx
@@ -2,13 +2,23 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "@/components/AppProvider";
 import { useStore } from "@/lib/store";
-import { buildSearch, loadExtSearch, fetchExtPerfume, selectExtHits, type ExtIndexEntry } from "@/lib/perfumes";
+import {
+  buildSearch,
+  loadExtSearch,
+  fetchExtPerfume,
+  rankSearchHits,
+  type RankCandidate,
+  type ExtIndexEntry,
+} from "@/lib/perfumes";
 import { nameParts } from "@/lib/format";
 import { ManualAdd } from "@/components/library/ManualAdd";
 import type { Perfume } from "@/lib/types";
 
-// 三级搜索兜底：主目录（Top1500 全中文）→ 扩展集（3.6 万款，英文名/品牌/国货中文）→ 手动记一瓶。
-// 柜是推荐引擎的唯一输入——搜不到 = 进不了柜 = 整条产品路径对那瓶香失效，所以这里必须有底。
+// 候选合并成一张榜单：主目录（Top1500 全中文）与扩展集（3.6 万款）统一重排，不分区——
+// 「更多结果」式区隔会让用户以为上面没有匹配（真实用户反馈）。排序见 rankSearchHits。
+// 搜不到的最后防线仍是手动记一瓶。
+type MergedItem = { source: "main"; p: Perfume } | { source: "ext"; e: ExtIndexEntry };
+
 export function SearchAdd() {
   const { catalog } = useApp();
   const addPerfume = useStore((s) => s.addPerfume);
@@ -17,8 +27,7 @@ export function SearchAdd() {
   const inLib = useMemo(() => new Set(userPerfumes.map((u) => u.perfumeId)), [userPerfumes]);
 
   const [q, setQ] = useState("");
-  const [results, setResults] = useState<Perfume[]>([]);
-  const [extHits, setExtHits] = useState<ExtIndexEntry[]>([]);
+  const [items, setItems] = useState<MergedItem[]>([]);
   const [extBusyId, setExtBusyId] = useState<number | null>(null);
   const [extError, setExtError] = useState(false);
   const [manualOpen, setManualOpen] = useState(false);
@@ -34,21 +43,36 @@ export function SearchAdd() {
     setManualOpen(false);
     setExtError(false);
     if (!ms || !q.trim()) {
-      setResults([]);
-      setExtHits([]);
+      setItems([]);
       return;
     }
-    const hits = ms.search(q.trim()).slice(0, 8);
-    const main = hits.map((h) => byId.get(h.id as number)).filter(Boolean) as Perfume[];
-    setResults(main);
-    // 扩展集搜索无条件跑（索引懒加载一次，此后走缓存）——不能按"主目录命中不足"触发：
-    // 主目录 OR+fuzzy 的单字垃圾命中会凑数，「观夏」曾因此彻底搜不到。取舍见 selectExtHits。
     const query = q.trim();
+    const mainHits = ms.search(query).slice(0, 12);
+    const mainCands: RankCandidate<MergedItem>[] = mainHits
+      .map((h) => byId.get(h.id as number))
+      .filter(Boolean)
+      .map((p) => ({
+        item: { source: "main" as const, p: p! },
+        nameHay: `${p!.nameZh ?? ""} ${(p!.aliases ?? []).join(" ")} ${p!.name}`,
+        fullHay: `${p!.nameZh ?? ""} ${(p!.aliases ?? []).join(" ")} ${p!.name} ${p!.brandZh} ${p!.brand}`,
+        people: p!.people,
+      }));
+    // 先用主目录候选即时出结果（扩展索引首次加载有延迟），扩展候选到位后合并重排
+    setItems(rankSearchHits(query, mainCands));
     loadExtSearch().then((ext) => {
       if (!ext || qRef.current !== query) return; // 过期查询丢弃
-      const mainIds = new Set(main.map((p) => p.id));
-      const all = ext.search(query).filter((h) => !mainIds.has(h.i as number)) as unknown as ExtIndexEntry[];
-      setExtHits(selectExtHits(all, query, main.length));
+      const mainIds = new Set(mainCands.map((c) => (c.item as { p: Perfume }).p.id));
+      const extCands: RankCandidate<MergedItem>[] = (
+        ext.search(query).slice(0, 50) as unknown as ExtIndexEntry[]
+      )
+        .filter((e) => !mainIds.has(e.i))
+        .map((e) => ({
+          item: { source: "ext" as const, e },
+          nameHay: e.n,
+          fullHay: `${e.n} ${e.b} ${e.z ?? ""}`,
+          people: e.p,
+        }));
+      setItems(rankSearchHits(query, [...mainCands, ...extCands]));
     });
   }, [q, ms, byId]);
 
@@ -96,7 +120,7 @@ export function SearchAdd() {
         <div className="absolute z-20 mt-2 w-full animate-fade-in overflow-hidden rounded-lg border border-line bg-surface shadow-float">
           {manualOpen ? (
             <ManualAdd initialName={q.trim()} onDone={() => { setManualOpen(false); setQ(""); }} />
-          ) : results.length === 0 && extHits.length === 0 ? (
+          ) : items.length === 0 ? (
             <div className="flex flex-col items-center gap-3 px-4 py-5 text-center">
               <p className="text-sm text-ink-faint">
                 没搜到。试试英文名或品牌名——有些香水的中文昵称和官方名差得很远。
@@ -110,77 +134,69 @@ export function SearchAdd() {
             </div>
           ) : (
             <ul className="max-h-[60vh] overflow-y-auto py-1">
-              {results.map((p) => {
-                const added = inLib.has(p.id);
+              {items.map((it) => {
+                if (it.source === "main") {
+                  const p = it.p;
+                  const added = inLib.has(p.id);
+                  return (
+                    <li key={`m${p.id}`}>
+                      <button
+                        disabled={added}
+                        onClick={() => addPerfume(p.id)}
+                        className="flex w-full items-center justify-between px-4 py-2.5 text-left transition-colors hover:bg-sunken disabled:cursor-default disabled:hover:bg-transparent"
+                      >
+                        <div className="min-w-0">
+                          {(() => {
+                            const np = nameParts(p);
+                            return (
+                              <>
+                                <div className={`truncate text-[1rem] text-ink ${np.primaryIsZh ? "serif font-semibold" : "disp"}`}>
+                                  {np.primary}
+                                </div>
+                                <div className="mt-0.5 truncate text-[0.74rem] text-ink-faint">
+                                  {np.secondary ? `${np.secondary} · ` : ""}
+                                  {p.brandZh} · {p.styleTags[0]}
+                                </div>
+                              </>
+                            );
+                          })()}
+                        </div>
+                        <span
+                          className={`ml-3 shrink-0 rounded-pill px-2.5 py-1 text-[0.72rem] ${
+                            added ? "text-ink-faint" : "bg-ink text-paper"
+                          }`}
+                        >
+                          {added ? "已在柜" : "+ 入柜"}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                }
+                const e = it.e;
+                const added = inLib.has(e.i);
+                const busy = extBusyId === e.i;
                 return (
-                  <li key={p.id}>
+                  <li key={`e${e.i}`}>
                     <button
-                      disabled={added}
-                      onClick={() => addPerfume(p.id)}
+                      disabled={added || busy}
+                      onClick={() => addFromExt(e)}
                       className="flex w-full items-center justify-between px-4 py-2.5 text-left transition-colors hover:bg-sunken disabled:cursor-default disabled:hover:bg-transparent"
                     >
                       <div className="min-w-0">
-                        {(() => {
-                          const np = nameParts(p);
-                          return (
-                            <>
-                              <div className={`truncate text-[1rem] text-ink ${np.primaryIsZh ? "serif font-semibold" : "disp"}`}>
-                                {np.primary}
-                              </div>
-                              <div className="mt-0.5 truncate text-[0.74rem] text-ink-faint">
-                                {np.secondary ? `${np.secondary} · ` : ""}
-                                {p.brandZh} · {p.styleTags[0]}
-                              </div>
-                            </>
-                          );
-                        })()}
+                        <div className="disp truncate text-[1rem] text-ink">{e.n}</div>
+                        <div className="mt-0.5 truncate text-[0.74rem] text-ink-faint">{e.z || e.b}</div>
                       </div>
                       <span
                         className={`ml-3 shrink-0 rounded-pill px-2.5 py-1 text-[0.72rem] ${
                           added ? "text-ink-faint" : "bg-ink text-paper"
                         }`}
                       >
-                        {added ? "已在柜" : "+ 入柜"}
+                        {added ? "已在柜" : busy ? "取数据…" : "+ 入柜"}
                       </span>
                     </button>
                   </li>
                 );
               })}
-
-              {extHits.length > 0 && (
-                <>
-                  <li className="px-4 pb-1 pt-2.5 text-[0.68rem] uppercase tracking-wide text-ink-faint">
-                    更多结果 · 来自完整目录
-                  </li>
-                  {extHits.map((e) => {
-                    const added = inLib.has(e.i);
-                    const busy = extBusyId === e.i;
-                    return (
-                      <li key={e.i}>
-                        <button
-                          disabled={added || busy}
-                          onClick={() => addFromExt(e)}
-                          className="flex w-full items-center justify-between px-4 py-2.5 text-left transition-colors hover:bg-sunken disabled:cursor-default disabled:hover:bg-transparent"
-                        >
-                          <div className="min-w-0">
-                            <div className="disp truncate text-[1rem] text-ink">{e.n}</div>
-                            <div className="mt-0.5 truncate text-[0.74rem] text-ink-faint">
-                              {e.z || e.b}
-                            </div>
-                          </div>
-                          <span
-                            className={`ml-3 shrink-0 rounded-pill px-2.5 py-1 text-[0.72rem] ${
-                              added ? "text-ink-faint" : "bg-ink text-paper"
-                            }`}
-                          >
-                            {added ? "已在柜" : busy ? "取数据…" : "+ 入柜"}
-                          </span>
-                        </button>
-                      </li>
-                    );
-                  })}
-                </>
-              )}
 
               <li className="border-t border-line">
                 <button

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -360,25 +360,32 @@ test("「用力过猛」组合：甜重/浓白花 × 强扩散 × 通勤，压�
   assert.ok(computeRisks(loudSweet, ctx).some((r) => r.includes("用力过猛")));
 });
 
-test("selectExtHits：强命中无视主目录垃圾计数（「观夏」回归）；无强命中时才看主目录贫瘠度", async () => {
-  const { selectExtHits } = await import("./perfumes");
-  const guanxia = [
-    { i: 1, n: "Triple Tea 三重茶", b: "To Summer | 观夏", p: 261 },
-    { i: 2, n: "Cedarwood 昆仑煮雪", b: "To Summer | 观夏", p: 80 },
-  ];
-  const junk = [
-    { i: 9, n: "Random Summer", b: "Nobody", p: 10 },
-    { i: 10, n: "Another", b: "Nobody", p: 9 },
-  ];
-  // 回归核心：主目录被「夏」字垃圾命中凑到 7 条时，观夏的强命中仍必须给出
-  const picked = selectExtHits([...junk, ...guanxia], "观夏", 7);
-  assert.deepEqual(picked.map((e) => e.i), [1, 2]);
-  // 多词段：每段都得是连续子串
-  assert.deepEqual(selectExtHits([...junk, ...guanxia], "观夏 三重茶", 7).map((e) => e.i), [1]);
-  // 无强命中 + 主目录已有像样结果 → 不放噪音
-  assert.deepEqual(selectExtHits(junk, "蓝风铃", 5), []);
-  // 无强命中 + 主目录贫瘠 → 放出模糊命中兜底（拼写误差/英文场景）
-  assert.equal(selectExtHits(junk, "sumer", 0).length, 2);
+test("rankSearchHits：统一榜单——文本档位优先，同档位内按主流度；不分区不折叠", async () => {
+  const { rankSearchHits } = await import("./perfumes");
+  const C = (item: string, nameHay: string, fullHay: string, people: number) => ({ item, nameHay, fullHay, people });
+  // 「观夏」回归：品牌命中（档位2）必须排在主目录的单字垃圾命中（档位1）之前，
+  // 哪怕垃圾命中的投票人数高得多——高度匹配不许被热门度淹没
+  const merged = rankSearchHits("观夏", [
+    C("junk-popular", "诺亚", "诺亚 Nobody", 99999),
+    C("gx-tea", "Triple Tea 三重茶", "Triple Tea 三重茶 To Summer | 观夏", 261),
+    C("gx-snow", "Cedarwood 昆仑煮雪", "Cedarwood 昆仑煮雪 To Summer | 观夏", 80),
+  ]);
+  assert.deepEqual(merged, ["gx-tea", "gx-snow", "junk-popular"]);
+  // 名称直接命中（档位3）压过品牌命中（档位2）
+  const t3 = rankSearchHits("昆仑煮雪", [
+    C("brand-only", "别的", "别的 昆仑煮雪牌", 5000),
+    C("name-hit", "Cedarwood 昆仑煮雪", "Cedarwood 昆仑煮雪 To Summer | 观夏", 80),
+  ]);
+  assert.equal(t3[0], "name-hit");
+  // 同名多版本：同档位内更主流（投票更多）的版本在前
+  const versions = rankSearchHits("大地", [
+    C("flanker", "大地 限量版", "大地 限量版 Hermès", 800),
+    C("mainline", "大地", "大地 Hermès 爱马仕", 26000),
+  ]);
+  assert.deepEqual(versions, ["mainline", "flanker"]);
+  // 全无子串命中（拼写误差）→ 档位1 内按主流度，仍然给结果、不留空
+  const fuzzy = rankSearchHits("sumer", [C("a", "Summer Hit", "Summer Hit X", 10), C("b", "Another", "Another Y", 500)]);
+  assert.deepEqual(fuzzy, ["b", "a"]);
 });
 
 test("riskNote：场景解析的社交风险以受控字段进入风险列表", () => {

--- a/src/lib/perfumes.ts
+++ b/src/lib/perfumes.ts
@@ -103,25 +103,37 @@ export function loadExtSearch(): Promise<MiniSearch<ExtIndexEntry> | null> {
   return extIndexPromise;
 }
 
-// 扩展集命中的取舍（纯函数，可单测）。教训（「观夏」搜不到）：主目录的 OR+fuzzy 会用无关的
-// 单字命中凑数——搜「观夏」时「夏」字垃圾命中 7 条，若按"主目录不足 3 条才兜底"，扩展集永远轮不到。
-// 因此扩展搜索无条件跑，取舍放在这里：
-// 1. 强命中优先：查询的每个词段都是条目串（名+品牌+中文）的连续子串 → 这是用户要找的，直接给；
-// 2. 没有强命中时，只在主目录确实贫瘠（<3 条）才放出模糊命中——避免好查询下面挂一排噪音。
-export function selectExtHits<T extends ExtIndexEntry>(
-  hits: T[],
-  query: string,
-  mainCount: number,
-  limit = 5
-): T[] {
+// ===== 统一排序：主目录与扩展集合并成一张榜单（纯函数，可单测）=====
+// 两次教训沉淀于此：
+// ① 「观夏」搜不到——主目录 OR+fuzzy 用无关单字命中凑数，"主目录不足才兜底"的触发条件永远不成立；
+// ② 「闻献」被折叠——把扩展集放进「更多结果」区隔，用户会以为上面没有匹配、根本注意不到底部。
+// 因此：两个索引的候选**合并重排、不分区**。排序原则（产品定案）：
+// - 文本匹配档位优先：查询整体命中名称(3) > 命中名称+品牌(2) > 仅模糊命中(1)——
+//   高度匹配的结果必须靠前，不许被别的信号淹没；
+// - 同档位内按投票人数（主流度）：同名多版本时，更常用、更主流的版本在前。
+export interface RankCandidate<T> {
+  item: T;
+  nameHay: string; // 名称类字段拼串（中文名/别名/英文名）
+  fullHay: string; // 名称 + 品牌全串
+  people: number; // 社区投票人数（跨索引可比的主流度信号）
+}
+
+export function rankSearchHits<T>(query: string, cands: RankCandidate<T>[], limit = 9): T[] {
   const segs = query.toLowerCase().split(/\s+/).filter(Boolean);
   if (segs.length === 0) return [];
-  const strong = hits.filter((e) => {
-    const hay = `${e.n} ${e.b} ${e.z ?? ""}`.toLowerCase();
-    return segs.every((s) => hay.includes(s));
-  });
-  if (strong.length > 0) return strong.slice(0, limit);
-  return mainCount < 3 ? hits.slice(0, limit) : [];
+  const joined = segs.join("");
+  const tierOf = (c: RankCandidate<T>): number => {
+    const nameHay = c.nameHay.toLowerCase();
+    if (segs.every((s) => nameHay.includes(s)) || nameHay.includes(joined)) return 3;
+    const fullHay = c.fullHay.toLowerCase();
+    if (segs.every((s) => fullHay.includes(s)) || fullHay.includes(joined)) return 2;
+    return 1;
+  };
+  return cands
+    .map((c) => ({ c, tier: tierOf(c) }))
+    .sort((a, b) => b.tier - a.tier || b.c.people - a.c.people)
+    .slice(0, limit)
+    .map((x) => x.c.item);
 }
 
 export async function fetchExtPerfume(id: number): Promise<Perfume | null> {

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,0 +1,121 @@
+// 搜索端到端回归（真实构建产物）：主目录 + 扩展集合并重排后，
+// 国货与长尾必须出现在榜单头部——「观夏搜不到」「闻献被折叠到看不见」两个真实事故的守门员。
+// 依赖 public/data/（构建产物已入库），构建 3.6 万条索引约 1–2 秒，可接受。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import MiniSearch from "minisearch";
+import { rankSearchHits, type RankCandidate, type ExtIndexEntry } from "./perfumes";
+import type { Perfume } from "./types";
+
+function tokenize(text: string): string[] {
+  const tokens: string[] = [];
+  const re = /[a-zA-Z0-9]+|[一-鿿]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) tokens.push(m[0].toLowerCase());
+  return tokens;
+}
+
+// 与 src/lib/perfumes.ts buildSearch / loadExtSearch 相同的索引配置（此处独立构建以脱离 fetch）
+function buildIndexes() {
+  const catalog = JSON.parse(fs.readFileSync("public/data/perfumes.min.json", "utf8")) as Perfume[];
+  const main = new MiniSearch({
+    idField: "id",
+    fields: ["nameZh", "aliasText", "name", "brand", "brandZh", "notesText"],
+    storeFields: ["id"],
+    tokenize,
+    processTerm: (t) => t.toLowerCase(),
+    searchOptions: {
+      tokenize,
+      processTerm: (t) => t.toLowerCase(),
+      prefix: true,
+      fuzzy: 0.15,
+      boost: { nameZh: 4, aliasText: 4, name: 3, brandZh: 2, brand: 2 },
+      combineWith: "OR",
+    },
+  });
+  main.addAll(
+    catalog.map((p) => ({
+      ...p,
+      nameZh: p.nameZh ?? "",
+      aliasText: (p.aliases ?? []).join(" "),
+      notesText: p.notesFlat.join(" "),
+    })) as unknown as Perfume[]
+  );
+  const ext = JSON.parse(fs.readFileSync("public/data/ext-index.json", "utf8")) as ExtIndexEntry[];
+  const extMs = new MiniSearch<ExtIndexEntry>({
+    idField: "i",
+    fields: ["n", "b", "z"],
+    storeFields: ["i", "n", "b", "z", "p"],
+    tokenize,
+    processTerm: (t) => t.toLowerCase(),
+    searchOptions: {
+      tokenize,
+      processTerm: (t) => t.toLowerCase(),
+      prefix: true,
+      fuzzy: 0.15,
+      boost: { n: 3, z: 2, b: 2 },
+      combineWith: "OR",
+    },
+  });
+  extMs.addAll(ext);
+  const byId = new Map(catalog.map((p) => [p.id, p]));
+  return { main, extMs, byId };
+}
+
+// 复刻 SearchAdd 的合并逻辑（候选规模与字段拼串保持一致）
+function searchMerged(idx: ReturnType<typeof buildIndexes>, query: string): { label: string; source: string }[] {
+  const mainCands: RankCandidate<{ label: string; source: string }>[] = idx.main
+    .search(query)
+    .slice(0, 12)
+    .map((h) => idx.byId.get(h.id as number)!)
+    .filter(Boolean)
+    .map((p) => ({
+      item: { label: p.nameZh || p.name, source: "main" },
+      nameHay: `${p.nameZh ?? ""} ${(p.aliases ?? []).join(" ")} ${p.name}`,
+      fullHay: `${p.nameZh ?? ""} ${(p.aliases ?? []).join(" ")} ${p.name} ${p.brandZh} ${p.brand}`,
+      people: p.people,
+    }));
+  const mainIds = new Set(idx.main.search(query).slice(0, 12).map((h) => h.id as number));
+  const extCands: RankCandidate<{ label: string; source: string }>[] = (
+    idx.extMs.search(query).slice(0, 50) as unknown as ExtIndexEntry[]
+  )
+    .filter((e) => !mainIds.has(e.i))
+    .map((e) => ({
+      item: { label: `${e.n} / ${e.z || e.b}`, source: "ext" },
+      nameHay: e.n,
+      fullHay: `${e.n} ${e.b} ${e.z ?? ""}`,
+      people: e.p,
+    }));
+  return rankSearchHits(query, [...mainCands, ...extCands]);
+}
+
+test("E2E 真实数据：国货与长尾在统一榜单头部，主流版本优先", () => {
+  const idx = buildIndexes();
+
+  // 观夏：品牌命中必须占据榜首（此前被 7 条单字垃圾命中压到看不见）
+  const gx = searchMerged(idx, "观夏");
+  assert.ok(gx.length > 0, "观夏应有结果");
+  assert.ok(gx[0].label.includes("观夏"), `观夏榜首应为观夏产品，实际：${gx[0].label}`);
+  assert.ok(
+    gx.slice(0, 3).every((r) => r.label.includes("观夏")),
+    `观夏前三应全部相关：${gx.slice(0, 3).map((r) => r.label).join(" | ")}`
+  );
+
+  // 闻献：同为国货白名单（此前被折叠进「更多结果」区隔）
+  const wx = searchMerged(idx, "闻献");
+  assert.ok(wx[0].label.includes("闻献"), `闻献榜首应为闻献产品，实际：${wx[0].label}`);
+
+  // 昆仑煮雪：名称直接命中 → 榜首
+  const kl = searchMerged(idx, "昆仑煮雪");
+  assert.ok(kl[0].label.includes("昆仑煮雪"), `昆仑煮雪榜首错误：${kl[0].label}`);
+
+  // 大地：主流版本（爱马仕大地主线）优先于各种衍生版本
+  const dd = searchMerged(idx, "大地");
+  assert.ok(dd[0].label.includes("大地"), `大地榜首错误：${dd[0].label}`);
+  assert.equal(dd[0].source, "main", "大地主线来自主目录（最主流版本）");
+
+  // 蓝风铃：主目录经典款不受合并影响
+  const bell = searchMerged(idx, "蓝风铃");
+  assert.ok(bell[0].label.includes("蓝风铃"), `蓝风铃榜首错误：${bell[0].label}`);
+});


### PR DESCRIPTION
真实用户反馈：「闻献」「昆仑煮雪」搜得到但被折叠在「更多结果 · 来自完整目录」区隔里，用户完全没注意到——区隔让人误以为上面没有匹配。

**修复**：主目录与扩展集候选合并成一张榜单，`rankSearchHits` 统一重排——文本匹配档位优先（名称命中 > 名称+品牌命中 > 模糊命中），同档位内按投票人数（主流度）排序：高度匹配尽量靠前；同名多版本时更主流的版本在前；完整目录结果不再折叠。

**验证**：38/38 用例（新增真实数据端到端回归：观夏/闻献/昆仑煮雪榜首断言、「大地」主流版本优先、「蓝风铃」不受影响）；0 lint error；构建通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)