### PR TITLE
PR #22 合并后遗留的三个修复

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "node --import tsx --test src/lib/engine.test.ts src/lib/journal.test.ts src/lib/search.test.ts scripts/ci-workflow.test.mjs",
+    "test": "node --import tsx --test src/lib/engine.test.ts src/lib/journal.test.ts src/lib/search.test.ts src/lib/store.test.ts scripts/ci-workflow.test.mjs",
     "build:data": "node scripts/build.mjs",
     "build:ext": "node scripts/build-ext.mjs",
     "extract:terms": "node scripts/extract-terms.mjs",

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -683,6 +683,22 @@ test("季节错配文案同样要过票数门槛：三票的噪声不得说「�
   assert.ok(computeRisks(solid, summer).some((r) => r.includes("大家更多在冬季")));
 });
 
+test("说了「收着些」就得真的收：高温风险文案与喷量必须一致", () => {
+  // 蔚蓝浓香精真实数据 sil=2.17 amber=86。此前高温减量只认 sillage≥3.2，
+  // 于是 33℃ 下一边弹「高温里存在感会比你以为的更强，喷得收着些更稳」，
+  // 一边给出 3–4 下的最高档——文案承诺了引擎没做的事。
+  const blue = mk({ people: 20000, sillage: 2.17, sillageTier: 2, accords: acc([["citrus", 100], ["amber", 86]]) });
+  const mild = computeUsage(blue, C({ occasion: "casual", feel: "mild", tempC: 20 }));
+  const hot = computeUsage(blue, C({ occasion: "casual", feel: "hot_humid", tempC: 33, humidity: 78 }));
+  assert.ok(computeRisks(blue, C({ occasion: "casual", feel: "hot_humid", tempC: 33 })).some((r) => r.includes("收着些")));
+  assert.ok(hot.sprays[1] < mild.sprays[1], `说了收着就得收：mild=${mild.spraysLabel} hot=${hot.spraysLabel}`);
+  // 天气驱动的减量封顶 1 下：又强扩散又厚重也只减一次
+  const both = mk({ people: 20000, sillage: 3.5, sillageTier: 4, accords: acc([["amber", 80]]) });
+  const bm = computeUsage(both, C({ occasion: "casual", feel: "mild", tempC: 20 }));
+  const bh = computeUsage(both, C({ occasion: "casual", feel: "hot_humid", tempC: 33, humidity: 78 }));
+  assert.equal(bm.sprays[1] - bh.sprays[1], 1, "两条同时命中也只减 1 下");
+});
+
 test("织物提示是提示不是风险：它不得把裁决从 good 降级成 caution", () => {
   // 封闭场合（通勤/上班/正式）的部位建议里必然出现"衣物内侧"，从而触发织物留印提示。
   // 若这条提示参与裁决（computeVerdict 的规则是 risks.length > 0 → caution），

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -703,11 +703,18 @@ test("织物提示是提示不是风险：它不得把裁决从 good 降级成 c
   // 封闭场合（通勤/上班/正式）的部位建议里必然出现"衣物内侧"，从而触发织物留印提示。
   // 若这条提示参与裁决（computeVerdict 的规则是 risks.length > 0 → caution），
   // 最常见的那几个场合就会被无端全部降级——这是提示与风险混为一谈的典型代价。
-  const clean = mk({ people: 20000, sillageTier: 2, sillage: 2.0, accords: acc([["citrus", 60]]) });
-  const pick = buildPick(clean, C({ occasion: "work", feel: "mild", tempC: 20 }));
+  // 用会留印的组分（树脂/浸膏），清爽柑橘按机制本就不触发这条提示
+  const resin = mk({ people: 20000, sillageTier: 2, sillage: 2.0, accords: acc([["amber", 60], ["woody", 50]]) });
+  const pick = buildPick(resin, C({ occasion: "work", feel: "mild", tempC: 20 }));
   assert.ok(pick.usage.placement.some((x) => x.includes("衣物")), "前提：确实建议了喷衣物");
   assert.ok(pick.risks.some((r) => r.includes("留印子")), "前提：确实给了织物提示");
   assert.equal(pick.verdict, "good", "织物提示不该影响裁决");
+
+  // 反向：清爽柑橘同样建议喷衣物，但不该被这条噪音打扰
+  const fresh = mk({ people: 20000, sillageTier: 2, sillage: 2.0, accords: acc([["citrus", 100]]) });
+  const fp = buildPick(fresh, C({ occasion: "work", feel: "mild", tempC: 20 }));
+  assert.ok(fp.usage.placement.some((x) => x.includes("衣物")), "前提：也建议了喷衣物");
+  assert.ok(!fp.risks.some((r) => r.includes("留印子")), "柑橘不该触发留印提示");
 });
 
 test("riskNote：场景解析的社交风险以受控字段进入风险列表", () => {

--- a/src/lib/recommend.ts
+++ b/src/lib/recommend.ts
@@ -1,6 +1,9 @@
 // 推荐编排：打分 → 轮换加权 → 排序 → 主推 + 备选，并为每个候选附上用法/风险/理由/裁决
 import type { Perfume, Context, ScoredPick, Verdict, Bias, Feedback, Occasion, SuccessConfig } from "./types";
-import { score, type ScoreParts } from "./scoring";
+import { score, sweetness, balsamicWeight, type ScoreParts } from "./scoring";
+
+/** 单个 accord 强度（留印风险判定用） */
+const accordAt = (p: Perfume, en: string) => p.accords.find((a) => a.en === en)?.strength ?? 0;
 import { computeUsage, computeRisks, buildReasons } from "./usage";
 import { tempBand } from "./season";
 
@@ -60,8 +63,12 @@ export function buildPick(p: Perfume, ctx: Context, bias?: Bias): ScoredPick {
   // 对真丝、醋酸纤维和浅色外层是实打实的留印风险【行业惯例】。
   // 放在这里而不是 computeRisks 里，是为了避免把 placement 的判定逻辑抄第二份——
   // 条件就是"最终真的建议了衣物"，不需要再推导一遍。
-  if (usage.placement.some((x) => x.includes("衣物"))) {
-    risks.push("喷衣物请选内衬，避开真丝、醋酸和浅色外层——酒精和香精可能留印子。");
+  // 只对**真的会留印**的组分提示。机制是有色浸膏、树脂与香草醛的油渍及光氧化黄变，
+  // 清爽柑橘/水生本来就不在其列。不收窄的话，夏天几乎每张卡都建议喷衣物，
+  // 这句就会变成每次都出现的噪音——一条永远出现的提示等于没有提示。
+  const stainRisk = Math.max(sweetness(p), balsamicWeight(p)) >= 40 || accordAt(p, "tobacco") >= 40;
+  if (stainRisk && usage.placement.some((x) => x.includes("衣物"))) {
+    risks.push("喷衣物请选内衬，避开真丝、醋酸和浅色外层——它的树脂与浸膏可能留印子。");
   }
   const reasons = buildReasons(p, ctx, {
     season: parts.season,

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,0 +1,67 @@
+// 本机存储层的契约单测。
+// 注意一个有利的巧合：Node 环境没有 window，persist 的 storage 句柄是 undefined，
+// 于是每次 set 都会在 `.setItem` 上抛错——这正好**稳定复现**了浏览器里
+// 「localStorage 配额写满 / Safari 隐私模式 / 存储被策略禁用」那条罕见但真实的路径。
+// 也就是说这个文件里的断言在 Node 下比在浏览器里更严格。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { useStore } from "./store";
+
+test("importData 返回 false 只能意味着「一个字节都没动」", () => {
+  // 原实现把校验和 set 一起包在 try 里：写盘抛错 → 走 catch → 返回 false，
+  // 而此时内存状态**早已被替换**，UI 却会照着 false 说出
+  // 「导入没能完成，现在的数据没有被改动」——这句话是谎话。
+  const st = () => useStore.getState();
+
+  // ① 非 JSON → 拒收，状态不变
+  const before = st().userPerfumes.length;
+  assert.equal(st().importData("这不是 JSON"), false);
+  assert.equal(st().userPerfumes.length, before, "被拒时不得改动状态");
+
+  // ② JSON 但不是我们的备份 → 拒收，状态不变
+  assert.equal(st().importData(JSON.stringify({ 随便: 1 })), false);
+  assert.equal(st().userPerfumes.length, before, "被拒时不得改动状态");
+
+  // ③ userPerfumes 全部损坏 → 拒收（不是我们的备份），状态不变
+  assert.equal(st().importData(JSON.stringify({ userPerfumes: [{ 坏: true }] })), false);
+  assert.equal(st().userPerfumes.length, before, "被拒时不得改动状态");
+
+  // ④ 合法备份 → 必须返回 true 并真的落库。
+  //    本环境下 persist 一定会在写盘时抛错，正是要守的那条路径：
+  //    状态已换掉，就不许再报告成"没有改动"。
+  const good = JSON.stringify({
+    userPerfumes: [{ perfumeId: 485, addedAt: Date.now() }],
+    city: "北京",
+    occasion: "commute",
+  });
+  assert.equal(st().importData(good), true, "写盘失败也不得反过来说没导入");
+  assert.equal(st().userPerfumes.length, 1);
+  assert.equal(st().city, "北京");
+});
+
+test("previewImport：先看清代价，再决定要不要覆盖", () => {
+  const st = () => useStore.getState();
+  assert.equal(st().previewImport("这不是 JSON"), null);
+  const raw = JSON.stringify({
+    userPerfumes: [
+      { perfumeId: 485, addedAt: 1 },
+      { perfumeId: 17, addedAt: 2 },
+    ],
+    feedbacks: [
+      {
+        perfumeId: 485,
+        at: 1,
+        context: { season: "summer", daypart: "day", tempC: 30, occasion: "commute" },
+        rating: "perfect",
+      },
+    ],
+    wearLog: [
+      { d: "2026-07-01", perfumeId: 485, name: "浅蓝", fam: "citrus", occasion: "commute", tempC: 30, weatherText: "晴", feel: "hot_dry" },
+      { d: "2026-07-01", perfumeId: 17, name: "大地", fam: "citrus", occasion: "work", tempC: 30, weatherText: "晴", feel: "hot_dry" },
+    ],
+  });
+  // 香历按日去重：同一天两条只算一天——预览给的数字必须和真正落库后一致
+  assert.deepEqual(st().previewImport(raw), { perfumes: 2, feedbacks: 1, wearDays: 1 });
+  st().importData(raw);
+  assert.equal(st().wearLog.length, 1, "预览数与实际落库数必须一致");
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -306,13 +306,26 @@ export const useStore = create<State>()(
           return null;
         }
       },
+      // 返回 false 只能有一个含义：**文件被拒，状态一个字节都没动**。
+      // 调用方据此告诉用户「导入没能完成，现在的数据没有被改动」——这句话必须永远为真。
+      //
+      // 原实现把整段（含 set）包在一个 try 里，于是写盘失败会走进 catch 返回 false，
+      // 而此时内存状态**早已被替换**——UI 就会说出那句谎话。
+      // 触发场景不是假想：localStorage 配额写满、Safari 隐私模式、存储被策略禁用，
+      // `setItem` 都会抛。所以校验全部前置到 set 之前，set 之后一律视为已生效。
       importData: (raw) => {
+        let d: z.infer<typeof ImportSchema>;
+        let userPerfumes: UserPerfume[];
         try {
           const parsed = ImportSchema.safeParse(JSON.parse(raw));
           if (!parsed.success) return false;
-          const d = parsed.data;
-          const userPerfumes = keepValid(d.userPerfumes, UserPerfumeSchema);
+          d = parsed.data;
+          userPerfumes = keepValid(d.userPerfumes, UserPerfumeSchema);
           if (userPerfumes.length === 0 && d.userPerfumes.length > 0) return false; // 全坏 = 不是我们的备份
+        } catch {
+          return false;
+        }
+        try {
           set((s) => ({
             userPerfumes,
             feedbacks: keepValid(d.feedbacks, FeedbackSchema).slice(-400) as Feedback[],
@@ -326,10 +339,14 @@ export const useStore = create<State>()(
             dustyAdoptCount:
               typeof d.dustyAdoptCount === "number" ? d.dustyAdoptCount : s.dustyAdoptCount,
           }));
-          return true;
         } catch {
-          return false;
+          // zustand 的 persist 是先改内存、再写盘，所以抛到这里时状态**已经换掉了**。
+          // 写盘失败（配额满 / 隐私模式 / 存储被禁）不该反过来报告成"没有改动"——
+          // 那是这次修复要消灭的那句谎话。这里吞掉异常但仍返回 true。
+          // 已知局限：写盘失败本身没有对用户暴露。但这个暴露面是全局的
+          //（addPerfume / addFeedback 等每一次写入都一样），不该只在导入这一处单独处理。
         }
+        return true;
       },
     }),
     {

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -70,7 +70,14 @@ export function computeUsage(p: Perfume, ctx: Context, bias?: Bias): Usage {
   // 事实上干热下蒸发散热有效，皮温往往还低于同气温的湿热。所以两者都保护，不再厚此薄彼。
   const hotFeel = ctx.feel === "hot_humid" || ctx.feel === "hot_dry";
   if (ctx.feel === "cold" && sil < 2.4) hi = Math.min(hi + 1, 5);
-  if (hotFeel && sil >= 3.2) hi = Math.max(lo, hi - 1);
+  // 高温减量有两条触发：扩散本身强，或这瓶偏甜/偏树脂（computeRisks 会为后者写出
+  // 「高温里存在感会比你以为的更强，喷得收着些更稳」）。第二条是为了让**已经说出口的那句话兑现**——
+  // 此前只认 sillage≥3.2，于是蔚蓝浓香精(sil=2.17, amber=86) 在 33℃ 会一边被提醒"收着些"、
+  // 一边拿到 3–4 下的最高档，文案与数字互相打脸。
+  // 【天气驱动的减量总计封顶 1 下】——两条同时命中也只减一次，避免叠加过度。
+  if (hotFeel && (sil >= 3.2 || Math.max(sweetness(p), balsamicWeight(p)) >= 55)) {
+    hi = Math.max(lo, hi - 1);
+  }
   // 餐桌场合：气味干扰味觉，收一档
   if (ctx.meal) hi = Math.max(lo, hi - 1);
   // 甜重/浓白花 × 强扩散 × 通勤会议：容易显得用力过猛，压到 1 下（与风险文案一致）
@@ -283,6 +290,10 @@ export function buildReasons(
   ctx: Context,
   parts: { season: number; weather: number; weatherTone: WeatherTone; occasion: number; confidence: number }
 ): string[] {
+  // 无香场合：结论是"今天别用"，就不该再罗列它今天多合适。
+  // 「正是它的主场季」「正合今天的天气」与「今天把它留在家里」同屏出现，
+  // 和「今天不建议用它」下面挂着「喷 2 下」是同一种自相矛盾。
+  if (ctx.fragranceFree) return [];
   const r: string[] = [];
   const topAccords = p.accords.slice(0, 3).map((a) => a.zh).join("·");
   // 「社区投票里…」是一句关于数据的断言：没有足够的票就没有资格说。


### PR DESCRIPTION
PR #22 合并后，分支上又落了三个提交，没能进 main。这个 PR 把它们接上。

净改动：6 文件 +136/−11。测试 **58 → 61**。

## 1. `fix(store)` importData 返回 false 时，必须真的什么都没动

调用方据 `false` 告诉用户「导入没能完成，**现在的数据没有被改动**」。原实现把校验和 `set` 包在同一个 try 里，于是**写盘失败会走进 catch 返回 false，而此时内存状态早已被替换**——那句话就成了谎话。

触发场景不是假想：zustand 的 persist 先改内存、再写 localStorage，配额写满 / Safari 隐私模式 / 存储被策略禁用时 `setItem` 都会抛。

修法：全部校验前置到 `set` 之前，让 `false` 只可能意味着"文件被拒"；`set` 之后即使写盘抛错也返回 `true`，并就地吞掉异常（否则异常会穿透到 profile 页未加保护的调用点）。

新增 `src/lib/store.test.ts`。有个有利的巧合：**Node 没有 `window`，persist 句柄为 undefined，每次 `set` 都会在 `.setItem` 上抛——正好稳定复现了浏览器里那条罕见路径**，断言在 Node 下比在浏览器里更严格。

## 2. `fix(engine)` 织物留印提示按机制收窄

只对真正会留印的组分（树脂/浸膏/烟草 ≥40）触发，清爽柑橘不再误报。理由写在注释里：不收窄的话夏天几乎每张卡都建议喷衣物，**一条永远出现的提示等于没有提示**。

## 3. `fix(engine)` 无香场合不再罗列「它今天多合适」

高温风险文案与喷量对齐。

---

本地：61/61 通过、lint 0 error、生产构建 10 页。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
