### PR TITLE
fix(deps): 修掉 nanoid 无限循环告警(GHSA-2v37-7h3g-55p8)，并让审计门禁回到绿

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6008,9 +6008,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -822,9 +822,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -903,9 +903,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3226,9 +3226,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4040,9 +4040,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4326,9 +4326,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
关闭 https://github.com/MrBaoboer/FenCun/security/dependabot/9

## nanoid 3.3.16 → 3.3.18（本次的正题）

GHSA-2v37-7h3g-55p8 / CVE-2026-67213，high，CWE-835：`customAlphabet` 与
`customRandom` 拿到 `size=0` 时，内部生成循环永远不满足退出条件，直接把调用线程转死。
补丁版是 3.3.17。

nanoid 是 `postcss` 的传递依赖，postcss 声明的是 `^3.3.16`——3.3.18 本来就落在范围内，
所以只动 lockfile，`package.json` 不用加 override。

## brace-expansion 1.1.16 → 1.1.18 / 5.0.8 → 5.0.9（顺手，但不顺手就到不了绿）

`scripts/audit-gate.mjs` 在改动之前**就已经是红的**：GHSA-rgw5-rvv9-x895
（绕过 CVE-2026-14257 缓解的无界中间数组 DoS）不在具名豁免清单里。这条跟 nanoid 无关，
但留着的话这个 PR 的 CI 到不了绿。

门禁里那条豁免写的理由是「1.x 到 1.1.16 终结、无补丁版」——上游已经把补丁补上了：
1.1.18 与 5.0.9 都已发布，分别落在 minimatch@3 的 `^1.1.7` 与现有 5.x 范围内。
不需要 override，也不会踩到 5.x 改命名导出、minimatch@3 的 `require` 拿到对象那个坑。
全部 5 处都是 dev 依赖。

豁免条目**没有删**：`scripts/ci-workflow.test.mjs:42` 断言清单不许为空
（按它自己的说法，空清单的正确做法是把整套机制删掉，那是另一个决定，不在本 PR 范围）。
门禁现在退出 0，并打印「该豁免已不再触发，可以删掉了」作为提示。

## 验证

改动只有 `package-lock.json`（18 增 18 删，全是 version / resolved / integrity），
`package.json` 未动。在合并后的状态上跑过：

- `npm audit` → **0 vulnerabilities**
- `node scripts/audit-gate.mjs` → exit 0
- `npm run lint` → 0 errors（8 条既有 warning，与依赖无关）
- `npm test` → **136 / 136 通过**
- `npm run build` → 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)