### PR TITLE
build: 依赖与运行时刷新——next 16.3.0、Node 24，并清掉三处已达退出条件的约束

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,15 +16,21 @@ updates:
         patterns:
           ["eslint*", "typescript", "tailwindcss", "@tailwindcss/*", "tsx", "puppeteer-core"]
     ignore:
-      # eslint 10 / typescript 6 的 major 由工具链（eslint-config-next）兼容性决定，
-      # 现阶段 eslint 10 会让 eslint-config-next 内置的 eslint-plugin-react 崩掉 → 忽略其 major，
-      # 待生态跟进后手动升级；minor / patch 仍照常跟进。
+      # eslint / typescript 的 major 由 eslint-config-next 那串内置插件的 peer 范围决定，
+      # 不是我们自己能选的。每次想解禁，去核这两组声明——达标了就手动升，别等 Dependabot：
+      #   eslint 10  ← eslint-plugin-react 7.37.5 / eslint-plugin-import 2.32.0 /
+      #                eslint-plugin-jsx-a11y 6.10.2 的 peer 都封顶在 9（react 那条是 ^9.7）
+      #   typescript ← typescript-eslint 8.66.0 的 peer 是 >=4.8.4 <6.1.0，而 npm 上的
+      #                latest 已经是 7.x（原生编译器），中间的 6.x 还只有 beta
+      # minor / patch 仍照常跟进。
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
-      # @types/node 跟随 Node 运行时大版本（CI 与 Vercel 均为 Node 22），不跳到领先运行时的 26
-      # （否则会拿到 Node 22 上并不存在的 API 类型）→ 忽略其 major，minor / patch 仍在 22.x 内跟进。
+      # @types/node 跟随 Node 运行时大版本——现在是 24（见 package.json 的 engines.node，
+      # 它同时决定 CI 与 Vercel）。不跳到领先运行时的 26：那会拿到 Node 24 上并不存在的
+      # API 类型，而 Node 26 要到 2026-10-28 才是 LTS。→ 忽略其 major，minor / patch 仍在 24.x 内跟进。
+      # 运行时本身升级时，这三处要一起动：engines.node、ci.yml 的 node-version、这条 ignore。
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
   # 保持 CI 里钉了 SHA 的第三方 Action 也能被跟进更新

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          # 与 package.json 的 engines.node 同一个大版本。那边是 Vercel 实际用的那条
+          # （engines.node 覆盖项目面板设置），这里跟着它走，CI 与生产才是同一个运行时。
+          node-version: 24
           cache: npm
       - name: Install
         run: npm ci
@@ -52,7 +54,9 @@ jobs:
       # Scan the complete reachable history so force-pushes and root commits do not
       # depend on an event-derived `before^..after` range.
       - name: Gitleaks (full history)
-        uses: docker://ghcr.io/gitleaks/gitleaks@sha256:e1b35e12a8c6fa8901f060459cfb6b2fc4c484d3afbe3b029733a3bbfab07055 # v8.24.3
+        # Dependabot 的 github-actions 生态不跟进 `docker://` 引用——这个摘要在 v8.24.3
+        # 上停了半年没人推，是手动核对上游 release 后换的。改版本时记得一起改注释里的 tag。
+        uses: docker://ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f # v8.30.1
         env:
           GIT_CONFIG_COUNT: "1"
           GIT_CONFIG_KEY_0: safe.directory

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: javascript-typescript
           build-mode: none
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:javascript-typescript"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "minisearch": "^7.1.2",
-        "next": "16.2.12",
+        "next": "16.3.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "zod": "^4.4.3",
@@ -18,15 +18,18 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^22",
+        "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "16.2.12",
-        "puppeteer-core": "^25.4.0",
+        "eslint-config-next": "16.3.0",
+        "puppeteer-core": "^25.5.0",
         "tailwindcss": "^4",
-        "tsx": "^4.23.1",
+        "tsx": "^4.23.11",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1648,25 +1651,26 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
-      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.12.tgz",
-      "integrity": "sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.0.tgz",
+      "integrity": "sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-utils": "4.9.1",
         "fast-glob": "3.3.1"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
-      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -1680,9 +1684,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
-      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -1696,9 +1700,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
-      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
       ],
@@ -1715,9 +1719,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
-      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
       ],
@@ -1734,9 +1738,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
-      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
       ],
@@ -1753,9 +1757,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
-      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
       ],
@@ -1772,9 +1776,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
-      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -1788,9 +1792,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
-      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -1852,9 +1856,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
-      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.1.0.tgz",
+      "integrity": "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2278,13 +2282,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -3430,6 +3434,31 @@
         "node": ">=20"
       }
     },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4006,13 +4035,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.12.tgz",
-      "integrity": "sha512-iaaf4vvKo5h2LBdGt0JuRv7t0Ysqr9FMCiFxbptDg8LqOE//mIKR80DdpOnSVM7qjLH3jT8P0aFiwXxBEGZRXw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.0.tgz",
+      "integrity": "sha512-lPrf1kHsMJEZqO0uXkNB400c5MGrhrTk3BNX7P0ol4gt61+iUlQfjy9TyIOEA9eOXrf+5+mYbT/JsY8+zqUByQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.12",
+        "@next/eslint-plugin-next": "16.3.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5991,9 +6020,9 @@
       "license": "MIT"
     },
     "node_modules/modern-tar": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6049,16 +6078,16 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
-      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.12",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -6068,15 +6097,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.12",
-        "@next/swc-darwin-x64": "16.2.12",
-        "@next/swc-linux-arm64-gnu": "16.2.12",
-        "@next/swc-linux-arm64-musl": "16.2.12",
-        "@next/swc-linux-x64-gnu": "16.2.12",
-        "@next/swc-linux-x64-musl": "16.2.12",
-        "@next/swc-win32-arm64-msvc": "16.2.12",
-        "@next/swc-win32-x64-msvc": "16.2.12",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -6451,13 +6480,13 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.4.0.tgz",
-      "integrity": "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.5.0.tgz",
+      "integrity": "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.0.6",
+        "@puppeteer/browsers": "3.1.0",
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1653615",
         "typed-query-selector": "^2.12.2",
@@ -6953,29 +6982,21 @@
       }
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -7307,9 +7328,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7481,9 +7502,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7719,6 +7740,31 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ws": {
       "version": "8.21.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
@@ -7759,16 +7805,16 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "string-width": "^8.2.1",
         "y18n": "^5.0.5",
         "yargs-parser": "^22.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "氛寸 — 基于实时情境的个人用香决策 Agent",
+  "_engines注释": "运行时版本的唯一事实源。Vercel 明确规定 engines.node 覆盖项目面板里选的版本，写在这里就不必再去对一个仓库外、谁也审计不了的设置。选 24 的理由：Node 22 已于 2025-10-21 进入维护期，24 自 2025-10-28 起是 Active LTS。改这里要连同 .github/workflows/ci.yml 的 node-version 与 devDependencies 的 @types/node 一起改，三者必须同一个大版本。",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -18,7 +22,7 @@
   },
   "dependencies": {
     "minisearch": "^7.1.2",
-    "next": "16.2.12",
+    "next": "16.3.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "^4.4.3",
@@ -26,22 +30,14 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^22",
+    "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.2.12",
-    "puppeteer-core": "^25.4.0",
+    "eslint-config-next": "16.3.0",
+    "puppeteer-core": "^25.5.0",
     "tailwindcss": "^4",
-    "tsx": "^4.23.1",
+    "tsx": "^4.23.11",
     "typescript": "^5"
-  },
-  "_overrides注释": {
-    "postcss": "长期项。next 把 postcss 钉在 8.4.31，而 @tailwindcss/postcss 要 ^8.5.x；两者不抬到同一条线上装不起来。",
-    "sharp": "临时项，为消 Dependabot 高危告警而抬。它把版本顶出了 next 声明的 optionalDependencies ^0.34.5，而 sharp 是 0.x、0.34→0.35 按 semver 即破坏性变更——等于替 next 宣称一个它没验证过的组合可用。实际风险接近零：sharp 只在 next/image 的图片优化路径上被 require，本仓库零引用，运行期永不加载。next 把 optionalDependencies 提到 ^0.35 之后即可删除本条。"
-  },
-  "overrides": {
-    "postcss": "^8.5.18",
-    "sharp": "^0.35.3"
   }
 }

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -18,17 +18,13 @@ import { execSync } from "node:child_process";
 /**
  * 具名豁免。每一条都必须写清：为什么无解、什么条件下可以删掉。
  * 加一条之前先问：是真的无解，还是只是升级麻烦？
+ *
+ * 现在是空的——这是门禁的正常状态，不是机制失效。上一条（brace-expansion 的
+ * GHSA-mh99-v99m-4gvg）当时判定「1.x 到 1.1.16 终结、无补丁版」，后来上游发了
+ * 1.1.18，条件达成即删。清单空着的时候门禁行为不变：全树扫描，任何 high/critical
+ * 一律红。
  */
-const ALLOW = [
-  {
-    id: "GHSA-mh99-v99m-4gvg",
-    package: "brace-expansion",
-    why: "仅出现在开发链路（eslint 插件 → minimatch@3 → brace-expansion@1）。"
-      + "1.x 到 1.1.16 终结、无补丁版；全局 override 到 5.x 会让 eslint 起不来（5.x 改成命名导出，"
-      + "minimatch@3 的 require 拿到对象）；升 eslint@10 又会打断 eslint-config-next 内置的 eslint-plugin-react。",
-    until: "上游 eslint-plugin-* 迁到新的 minimatch 之后即可删除本条。",
-  },
-];
+const ALLOW = [];
 
 const allowIds = new Set(ALLOW.map((a) => a.id));
 const BLOCKING = new Set(["high", "critical"]);
@@ -86,4 +82,8 @@ if (unexpected.length > 0) {
   process.exit(1);
 }
 
-console.log(`\n依赖审计通过：全树扫描，${findings.length} 条 high/critical 全部具名豁免。`);
+console.log(
+  findings.length === 0
+    ? "\n依赖审计通过：全树扫描，无 high/critical 公告。"
+    : `\n依赖审计通过：全树扫描，${findings.length} 条 high/critical 全部具名豁免。`,
+);

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -37,9 +37,12 @@ test("CI blocks high-severity vulnerabilities in shipped dependencies", async ()
 test("每一条依赖豁免都必须写清为什么无解、什么条件下能删", async () => {
   // 门禁从 `--omit=dev`（整棵开发依赖树的匿名豁免）换成具名清单之后，
   // 真正要守的就变成了这件事：清单不许悄悄变长，也不许出现一条没写理由的豁免。
+  //
+  // 清单为空是正常状态（上游把公告修掉了，豁免按 until 条件删掉），此时门禁行为
+  // 与「无豁免的全树审计」等价，仍然在干活。要守的不是「至少有一条」，而是下面
+  // 这两件：有几条就每条都得写清理由与退出条件，且门禁始终是全树的。
   const src = await readFile(new URL("./audit-gate.mjs", import.meta.url), "utf8");
   const entries = [...src.matchAll(/id:\s*"(GHSA-[\w-]+)"/g)].map((m) => m[1]);
-  assert.ok(entries.length > 0, "豁免清单为空时应当直接删掉这套机制，而不是留一个空壳");
   for (const id of entries) {
     const block = src.slice(src.indexOf(`id: "${id}"`));
     const why = block.match(/why:\s*"([^"]+)"/)?.[1] ?? "";
@@ -57,8 +60,8 @@ test("新增的测试文件不许静默不跑：npm test 的清单必须覆盖�
   // 「引擎改动必须附回归测试」，而新贡献者建一个 src/lib/usage.test.ts 让它本地通过之后，
   // npm test 与 CI 都不会执行它——绿灯、零信号，是最难察觉的那种失败形态。
   //
-  // 这里不改成 glob：`node --test` 的 glob 展开在不同 Node 版本上行为不一（CI 跑的是 22，
-  // 本机是 24），把门禁的可靠性押在运行时语义上不划算。改成让清单漏一个就红。
+  // 这里不改成 glob：`node --test` 的 glob 展开在不同 Node 版本上行为不一，把门禁的
+  // 可靠性押在运行时语义上不划算。改成让清单漏一个就红。
   const { readdir } = await import("node:fs/promises");
   const root = new URL("../", import.meta.url);
   const pkg = JSON.parse(await readFile(new URL("package.json", root), "utf8"));


### PR DESCRIPTION
一轮依赖与工具链盘点，把能升的升掉、把三处已经达成退出条件的约束清掉，并把运行时版本落进仓库。

## 升了什么

| 项 | 从 → 到 |
|---|---|
| `next` | 16.2.12 → **16.3.0**（连带 `eslint-config-next`） |
| `puppeteer-core` | 25.4.0 → 25.5.0 |
| `tsx` | 4.23.1 → 4.23.11 |
| `@types/node` | 22.20.1 → **24.13.3** |
| `codeql-action` | v4.37.4 → **v4.37.6** |
| `gitleaks` | v8.24.3 → **v8.30.1** |

## 三处已达退出条件的约束，清掉

**两条 `overrides` 全删。** next 16.3.0 把 `dependencies.postcss` 从 8.4.31 抬到 8.5.23、`optionalDependencies.sharp` 从 `^0.34.5` 抬到 `^0.35.3`——正是 `_overrides注释` 里给两条各自写的退出条件。删后解析结果一字未变：postcss 8.5.23 单份去重、sharp 0.35.3。

**审计豁免清单清空。** 上游发了 `brace-expansion@1.1.18`，GHSA-mh99-v99m-4gvg 不再触发，门禁自己也在打印「可以删掉了」。`ci-workflow.test.mjs` 里那条「清单为空就该删掉整套机制」的断言改成「有几条就每条都得写清理由与退出条件」——机制留着：近一个月已连撞 postcss / brace-expansion / nanoid 三次，删了几周内还得重建。门禁行为不变，全树 high/critical 一律红。

**gitleaks 为什么漂了半年。** Dependabot 的 github-actions 生态不跟进 `uses: docker://` 引用，哪怕行尾已经写了 `# v8.24.3`。这类引用只能手动核上游 release，理由写进 `ci.yml` 注释了。

## 运行时升到 Node 24

`package.json` 新增 `engines.node: "24.x"`。Vercel 明确规定 **`engines.node` 覆盖项目面板里选的版本**，写进仓库之后运行时版本才是可审计、能进评审的，不必再去对一个仓库外的设置。

依据取自 `nodejs/Release` 的 `schedule.json`：

| | 状态 |
|---|---|
| Node 22 | 已于 2025-10-21 进入维护期 |
| Node 24 | 自 2025-10-28 起是 **Active LTS** |
| Node 26 | 要到 2026-10-28 才是 LTS |

`engines.node`、`ci.yml` 的 `node-version`、`@types/node` 三处同步到 24，这条约束写进了 `_engines注释` 与 `dependabot.yml`。

> ⚠️ 这条会改生产运行时。本 PR 的 Vercel 预览部署会先真跑一遍 Node 24，合并前可以看结果。

## 两个大版本实测仍升不了

不是按 peer 声明推断的，是建独立探针真跑出来的：

- **eslint 10.8.1** 能装上（npm 只报 3 条 ERESOLVE 警告），但一跑就整体崩：`eslint-plugin-react` 7.37.5 调了 ESLint 10 已删除的 `context.getFilename()`，`TypeError` at `version.js:31`，在加载第一个文件时就死。
- **typescript 7.0.2** — `typescript-eslint` 8.66.0 在模块加载时直接 `throw Error("typescript-eslint does not support TS 7.0.")`，`npm run lint` 连启动都做不到。**但 TS 7 对本仓库源码 `tsc --noEmit` 是干净的（exit 0）**——卡住的只有 lint 工具链，上游一支持大概率就是一行改动。

两条的解禁依据都写进了 `dependabot.yml` 的 ignore 注释，下次不必重新调查。

## 验证

- `tsc --noEmit` 干净
- 136/136 用例
- `npm run lint` 0 error / 8 warning（既有基线）
- 生产构建 13 页
- `npm audit` 0 漏洞，锁文件无弃用包
- 浏览器实测生产服务器：今日 / 香柜 / 香历 / 我的四页全渲染，零控制台错误、零服务端错误
