### PR TITLE
fix(obs): 两条 LLM 路由的降级分支不再静默，按原因分级记日志

### DIFF
--- a/src/app/api/explain/route.ts
+++ b/src/app/api/explain/route.ts
@@ -5,6 +5,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { allow, clientKey, withinDailyBudget, fromOwnPage } from "@/lib/ratelimit";
+import { classifyFetchError, describeChoice, logDegrade, readUpstreamError } from "@/lib/llmlog";
 import {
   extractDigits,
   findInventedNumbers,
@@ -141,7 +142,21 @@ export async function POST(req: NextRequest) {
   const fallback = template(input);
   // 无 key 或被限流 → 直接返回免费的规则模板（不打 DeepSeek），UX 不断、成本可控。
   // 限流 8 次/10 秒：客户端有 550ms 防抖 + 结果缓存，正常人远用不到；剩下的是脚本。
-  if (!KEY || !allow(`explain:${clientKey(req)}`, 8, 10_000) || !withinDailyBudget()) {
+  //
+  // 三条拆开写只为把降级原因记准：`!KEY || !allow(…) || !withinDailyBudget()` 挤在一行时，
+  // 日志只能说"降级了"，说不出是哪一条——而这三条的处置完全不同（配环境变量 / 有人在刷 /
+  // 当天额度用完了）。求值顺序与短路语义逐字保留：allow() 和 withinDailyBudget() 都会
+  // **消费计数**，把它们提到 !KEY 之前或互换位置都会改变限流与闸门的实际口径。
+  if (!KEY) {
+    logDegrade("explain", { kind: "no_key" });
+    return NextResponse.json({ text: fallback, source: "template" });
+  }
+  if (!allow(`explain:${clientKey(req)}`, 8, 10_000)) {
+    logDegrade("explain", { kind: "rate_limited" });
+    return NextResponse.json({ text: fallback, source: "template" });
+  }
+  if (!withinDailyBudget()) {
+    logDegrade("explain", { kind: "budget_exhausted" });
     return NextResponse.json({ text: fallback, source: "template" });
   }
 
@@ -205,6 +220,9 @@ export async function POST(req: NextRequest) {
     ...input.risks,
   ].join(" ");
 
+  // 上游那一跳的耗时。它是排查时第一眼要看的数：一次快速失败（几百毫秒的 401/402）
+  // 与一次卡到超时（15s）在 body 上完全同形，只有这个数分得开。
+  const startedAt = Date.now();
   try {
     const res = await fetch(`${BASE}/chat/completions`, {
       method: "POST",
@@ -224,13 +242,33 @@ export async function POST(req: NextRequest) {
       }),
       signal: AbortSignal.timeout(15000),
     });
-    if (!res.ok) return NextResponse.json({ text: fallback, source: "template" });
+    if (!res.ok) {
+      // 状态码 + 上游自己的错误消息。401（key 无效）与 402（余额不足）只有后者分得开，
+      // 而这两种的处置一个是轮换密钥、一个是充值——分不出就等于没排查。
+      logDegrade(
+        "explain",
+        { kind: "upstream_status", status: res.status, detail: await readUpstreamError(res) },
+        Date.now() - startedAt
+      );
+      return NextResponse.json({ text: fallback, source: "template" });
+    }
     const data = await res.json();
-    const text: string | undefined = data?.choices?.[0]?.message?.content?.trim();
-    if (!text) return NextResponse.json({ text: fallback, source: "template" });
+    const choice = data?.choices?.[0];
+    const text: string | undefined = choice?.message?.content?.trim();
+    if (!text) {
+      // 上游 200 却拿不到正文，有好几种成因，处置完全不同（见 llmlog.ts:describeChoice）。
+      // 只记 finish_reason 与字符数——正文本身是模型对用户原话的转写，不进日志。
+      logDegrade(
+        "explain",
+        { kind: "bad_shape", at: "empty_text", detail: describeChoice(choice) },
+        Date.now() - startedAt
+      );
+      return NextResponse.json({ text: fallback, source: "template" });
+    }
     // 防线①（铁律 6 的代码级）：avoid 裁决的返回若不含否定语义（LLM 软化/漏说"不建议"），
     // 回退确定性模板（它天然以"说实话，今天不太建议"开头），不让 LLM 把该劝退的场景圆成可用。
     if (input.verdict === "avoid" && !NEGATIVE_VERDICT_RE.test(text)) {
+      logDegrade("explain", { kind: "guard", at: "avoid_softened" });
       return NextResponse.json({ text: fallback, source: "template" });
     }
     // 防线②（铁律 2 的代码级）：数字白名单。"反伪精确"不能只是提示词里的一句拜托。
@@ -244,7 +282,11 @@ export async function POST(req: NextRequest) {
       ...findUnitMismatch(text, allowedPairs),
     ];
     if (invented.length > 0) {
-      console.warn(`[explain] LLM 编造数字被拦截: ${invented.join(",")}`);
+      // 这条原本是全路由唯一记日志的分支，措辞也自成一格（「[explain] LLM 编造数字被拦截」）。
+      // 现在收进统一格式：一个降级面板不该按分支分成两种语法。被拦下的 token 本身
+      // 是数字与量词（"6.2"、"六个小时"），不是用户原话，照旧带上——它是判断
+      // 「防线该不该收紧」的全部依据。
+      logDegrade("explain", { kind: "guard", at: "invented_numbers", detail: invented.join(",") });
       return NextResponse.json({ text: fallback, source: "template" });
     }
     // 防线③：good 也不许被说反。裁决共三档，此前只有 avoid 一档有代码级校验——
@@ -254,10 +296,14 @@ export async function POST(req: NextRequest) {
     // 「同一条」此前只是说说：这里的字面量少了「慎」和「其实不」两个分支，测试里还抄了第三份。
     // 现在真的是同一个符号（NEGATIVE_VERDICT_RE）。
     if (input.verdict === "good" && NEGATIVE_VERDICT_RE.test(text)) {
+      logDegrade("explain", { kind: "guard", at: "good_reversed" });
       return NextResponse.json({ text: fallback, source: "template" });
     }
     return NextResponse.json({ text, source: "deepseek" });
-  } catch {
+  } catch (e) {
+    // 超时 / 连不通 / 200 但响应体不是 JSON——三种在这里分开记，
+    // 否则「我们自己设的 15s 到了」和「根本没连上 DeepSeek」会是同一句话。
+    logDegrade("explain", classifyFetchError(e), Date.now() - startedAt);
     return NextResponse.json({ text: fallback, source: "template" });
   }
 }

--- a/src/app/api/parse-intent/route.ts
+++ b/src/app/api/parse-intent/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { allow, clientKey, withinDailyBudget, fromOwnPage } from "@/lib/ratelimit";
+import { classifyFetchError, describeChoice, logDegrade, readUpstreamError } from "@/lib/llmlog";
 import { carriesNumber } from "@/lib/numguard";
 
 export const runtime = "nodejs";
@@ -142,11 +143,23 @@ export async function POST(req: NextRequest) {
   if (text.length > 120) text = text.slice(0, 120); // 输入上限：防超长/成本/注入面
 
   const fallback = { ...heuristic(text), source: "heuristic" as const };
-  // 无 key 或被限流 → 关键词启发式（不打 DeepSeek），仍能给出可用结构
-  if (!KEY || !allow(`parse:${clientKey(req)}`, 8, 10_000) || !withinDailyBudget()) {
+  // 无 key 或被限流 → 关键词启发式（不打 DeepSeek），仍能给出可用结构。
+  // 与 explain 同理，三条拆开只为把原因记准；求值顺序与短路语义逐字保留
+  //（allow() 与 withinDailyBudget() 都会消费计数，换位置就改了口径）。
+  if (!KEY) {
+    logDegrade("parse-intent", { kind: "no_key" });
+    return NextResponse.json(fallback);
+  }
+  if (!allow(`parse:${clientKey(req)}`, 8, 10_000)) {
+    logDegrade("parse-intent", { kind: "rate_limited" });
+    return NextResponse.json(fallback);
+  }
+  if (!withinDailyBudget()) {
+    logDegrade("parse-intent", { kind: "budget_exhausted" });
     return NextResponse.json(fallback);
   }
 
+  const startedAt = Date.now();
   try {
     const res = await fetch(`${BASE}/chat/completions`, {
       method: "POST",
@@ -164,21 +177,69 @@ export async function POST(req: NextRequest) {
       }),
       signal: AbortSignal.timeout(12000),
     });
-    if (!res.ok) return NextResponse.json(fallback);
+    if (!res.ok) {
+      logDegrade(
+        "parse-intent",
+        { kind: "upstream_status", status: res.status, detail: await readUpstreamError(res) },
+        Date.now() - startedAt
+      );
+      return NextResponse.json(fallback);
+    }
     const data = await res.json();
-    const raw = data?.choices?.[0]?.message?.content;
+    const choice = data?.choices?.[0];
+    const raw = choice?.message?.content;
     // 容错：模型偶发在 json_object 外带 ```json 围栏或解释文字 → 截取首个 { 到末个 } 再解析，
     // 避免白白丢掉一次本可用的 LLM 结果、降到粗粒度启发式
-    if (typeof raw !== "string") return NextResponse.json(fallback);
-    const s = raw.indexOf("{");
-    const e = raw.lastIndexOf("}");
-    if (s < 0 || e <= s) return NextResponse.json(fallback);
-    const parsed = PatchSchema.safeParse(JSON.parse(raw.slice(s, e + 1)));
-    if (!parsed.success) return NextResponse.json(fallback);
+    if (typeof raw !== "string") {
+      logDegrade(
+        "parse-intent",
+        { kind: "bad_shape", at: "no_content", detail: describeChoice(choice) },
+        Date.now() - startedAt
+      );
+      return NextResponse.json(fallback);
+    }
+    const start = raw.indexOf("{");
+    const end = raw.lastIndexOf("}");
+    if (start < 0 || end <= start) {
+      // 空字符串也落在这里（indexOf 返回 -1）。finish_reason 与 reasoning 长度是分辨
+      //「思考把 token 吃光了」和「模型没按 json_object 输出」的唯一依据。
+      logDegrade(
+        "parse-intent",
+        { kind: "bad_shape", at: "no_json", detail: describeChoice(choice) },
+        Date.now() - startedAt
+      );
+      return NextResponse.json(fallback);
+    }
+    // JSON.parse 单独包起来，不再让它落到外层 catch。行为不变（同一个 fallback），
+    // 变的是记账：模型写出坏 JSON 是**模型输出不合格**，不是「上游坏了」，
+    // 混进 upstream_error 会让告警指向一个没坏的 DeepSeek。
+    let patch: unknown;
+    try {
+      patch = JSON.parse(raw.slice(start, end + 1));
+    } catch {
+      logDegrade("parse-intent", { kind: "bad_shape", at: "json_parse" }, Date.now() - startedAt);
+      return NextResponse.json(fallback);
+    }
+    const parsed = PatchSchema.safeParse(patch);
+    if (!parsed.success) {
+      // 只记**字段路径**，不记 zod 的 received 值——那一侧是模型对用户原话的转写，
+      // 是这条链路上唯一可能把用户写的话带进日志的地方。路径足够定位是哪个字段在漂。
+      logDegrade(
+        "parse-intent",
+        {
+          kind: "bad_shape",
+          at: "schema",
+          detail: parsed.error.issues.map((i) => i.path.join(".") || "(root)").join(","),
+        },
+        Date.now() - startedAt
+      );
+      return NextResponse.json(fallback);
+    }
     const merged = unionFragranceFree(parsed.data, fallback);
     // label 与提示口径对齐（≤12 字），与启发式兜底一致，防超长撑版
     return NextResponse.json({ ...parsed.data, ...merged, label: merged.label.slice(0, 12), source: "deepseek" });
-  } catch {
+  } catch (e) {
+    logDegrade("parse-intent", classifyFetchError(e), Date.now() - startedAt);
     return NextResponse.json(fallback);
   }
 }

--- a/src/app/api/route.test.ts
+++ b/src/app/api/route.test.ts
@@ -274,6 +274,129 @@ test("来源校验：一个第三方网页不该能从访客浏览器里调走�
   assert.equal(fromOwnPage(req({ "content-type": "application/json; charset=utf-8" })), true);
 });
 
+// ---------- 降级可观测性 ----------
+
+test("降级分级：上游坏了要吵，按设计降级只记一笔", async () => {
+  // 此前两条 LLM 路由的八个降级分支里只有数字白名单那一条记日志，于是
+  //「线上 DeepSeek 一次都没打通」与「本地没配 key」在外部完全同形——
+  // HTTP 都是 200、body 都带 source: template/heuristic、日志里一片空白。
+  const { levelOf } = await import("@/lib/llmlog");
+  // 需要有人去修的：不修就永远降级，而用户完全无感
+  for (const k of ["upstream_status", "timeout", "upstream_error"] as const) {
+    assert.equal(levelOf(k), "error", `${k} 是上游坏了，必须按 error 记`);
+  }
+  // 系统正在按设计工作：README 明说没有 key 也能跑，限流与闸门是自我保护，
+  // guard 命中恰恰证明防线生效——这几条按 error 记就是在训练所有人忽略告警
+  for (const k of ["no_key", "rate_limited", "budget_exhausted", "bad_shape", "guard"] as const) {
+    assert.equal(levelOf(k), "warn", `${k} 是按设计降级，不该按 error 记`);
+  }
+});
+
+test("降级日志绝不写 key——这条约束要有东西守着，不能靠 review 肉眼扫", async () => {
+  const { degradeLine, redact } = await import("@/lib/llmlog");
+  // 夹具一律**拼**出来，不写成字面量：源码里出现一个长成 key 的串，gitleaks 的
+  // generic-api-key 就会命中（实测这条测试的第一版让全历史扫描红了两条）。
+  // 拼接后每个字面量都短于规则阈值，而运行期拿到的形态与真 key 完全一样。
+  const fakeKey = "sk-" + "0123456789".repeat(2);
+  const opaque = "A1b2C3d4".repeat(3);
+  // DeepSeek 的 401 错误体历来把 key 回显在消息里，而我们要记的正是这条消息
+  const real = `Authentication Fails, Your api key: ${fakeKey} is invalid`;
+  const line = degradeLine("explain", { kind: "upstream_status", status: 401, detail: real }, 312);
+  assert.ok(!line.includes(fakeKey), `key 漏进了日志：${line}`);
+  assert.ok(line.includes("Authentication Fails"), "抹得只剩状态码就失去了排查价值");
+  assert.ok(line.includes("status=401") && line.includes("ms=312"));
+  // 其余凭据形态
+  assert.ok(!redact("Authorization: Bearer abc.def.ghi").includes("abc.def.ghi"));
+  assert.ok(!redact(`token=${opaque}`).includes(opaque));
+  // 兜底截断：任何形态的长文本都进不了日志
+  const long = degradeLine("explain", { kind: "guard", at: "invented_numbers", detail: "9".repeat(500) });
+  assert.ok(long.length < 300, `detail 没截断：${long.length} 字符`);
+});
+
+test("降级日志分得出上游的四种坏法，而不是一句「失败了」", async () => {
+  const { classifyFetchError } = await import("@/lib/llmlog");
+  // ① 我们自己设的 12s / 15s 到了：AbortSignal.timeout() 抛的是 TimeoutError
+  const timeout = Object.assign(new Error("The operation was aborted"), { name: "TimeoutError" });
+  assert.deepEqual(classifyFetchError(timeout), { kind: "timeout" });
+  // ② 根本没连上：undici 统一包成 `TypeError: fetch failed`，真正的原因只在 cause.code。
+  //    只记外层消息等于什么都没记——三种网络失败会写出同一行字。
+  const dns = Object.assign(new TypeError("fetch failed"), { cause: { code: "ENOTFOUND" } });
+  const dnsReason = classifyFetchError(dns);
+  assert.ok(
+    dnsReason.kind === "upstream_error" && dnsReason.detail.includes("ENOTFOUND"),
+    "丢了 cause.code 就定位不到网络层"
+  );
+  // ③ 连上了但响应体不是 JSON（res.json() 抛 SyntaxError）
+  const badBody = classifyFetchError(new SyntaxError("Unexpected token < in JSON"));
+  assert.ok(badBody.kind === "upstream_error" && badBody.detail.includes("SyntaxError"));
+  // ④ 什么都不是的东西扔进来也不许炸——日志代码自己把请求搞崩是最坏的结果
+  assert.equal(classifyFetchError(null).kind, "upstream_error");
+  assert.equal(classifyFetchError("boom").kind, "upstream_error");
+});
+
+test("补日志不许顺手补出一条日志放大路径", async () => {
+  const { shouldLog } = await import("@/lib/llmlog");
+  const t0 = 1_000_000;
+  // no_key / budget_exhausted：KEY 是模块级常量、闸门触顶后当天每个请求都会再撞一次，
+  // 重复一万遍不会比第一遍多告诉你任何事
+  assert.equal(shouldLog("a:no_key", Infinity, t0), true);
+  assert.equal(shouldLog("a:no_key", Infinity, t0 + 86_400_000), false, "每实例只该记一次");
+  // rate_limited：由客户端行为触发、次数无上限，一个脚本就能把日志刷爆
+  assert.equal(shouldLog("b:rate_limited", 60_000, t0), true);
+  assert.equal(shouldLog("b:rate_limited", 60_000, t0 + 59_999), false);
+  assert.equal(shouldLog("b:rate_limited", 60_000, t0 + 60_000), true, "窗口过了要能再记");
+  // 上游坏了与防线拦截：频率本身就是信号，压掉就没了
+  for (let i = 0; i < 5; i++) assert.equal(shouldLog("c:upstream_status", 0, t0), true);
+});
+
+test("降级日志走对 console 通道，且上游错误体只取结构化字段", async (t) => {
+  const { logDegrade, readUpstreamError } = await import("@/lib/llmlog");
+  const warn = t.mock.method(console, "warn", () => {});
+  const error = t.mock.method(console, "error", () => {});
+
+  logDegrade("probe-a", { kind: "upstream_status", status: 402, detail: "Insufficient Balance" }, 480);
+  logDegrade("probe-a", { kind: "guard", at: "avoid_softened" });
+  assert.equal(error.mock.calls.length, 1, "上游坏了要进 error");
+  assert.equal(warn.mock.calls.length, 1, "防线拦截要进 warn");
+  assert.match(String(error.mock.calls[0].arguments[0]), /\[probe-a\] 降级 upstream_status status=402/);
+  assert.match(String(warn.mock.calls[0].arguments[0]), /\[probe-a\] 降级 guard at=avoid_softened/);
+
+  // 401 与 402 的区别（key 无效 / 余额不足）只写在上游的这条消息里，状态码本身分不出，
+  // 而两者的处置一个是轮换密钥、一个是充值
+  const paid = await readUpstreamError(
+    new Response(JSON.stringify({ error: { message: "Insufficient Balance" } }), { status: 402 })
+  );
+  assert.equal(paid, "Insufficient Balance");
+  // 非预期形态一律只记长度：那是唯一可能把请求内容回显进日志的路径，堵死它比事后截断可靠
+  const html = await readUpstreamError(new Response("<html>502 Bad Gateway 今晚和客户吃饭</html>", { status: 502 }));
+  assert.ok(!html.includes("今晚和客户吃饭"), `上游正文被原样搬进了日志：${html}`);
+  assert.match(html, /^非 JSON 错误体 \d+B$/);
+});
+
+test("上游 200 却没给出能用的东西：要分得出是哪一种，且一个字都不许记", async () => {
+  const { describeChoice } = await import("@/lib/llmlog");
+  // 思考型模型把 max_tokens 全花在推理上，正文一个字没轮到——修法是抬 max_tokens
+  // 或关思考，与「网络不通」「key 无效」没有任何关系，而这三者此前记出来是同一句话（没有）
+  const starved = describeChoice({
+    finish_reason: "length",
+    message: { content: "", reasoning_content: "用户说今晚和客户吃饭，包间……" },
+  });
+  assert.equal(starved, "finish=length content=0 reasoning=15");
+  // 模型真的什么都没说，与上面那种要分开
+  assert.equal(describeChoice({ finish_reason: "stop", message: { content: "" } }), "finish=stop content=0 reasoning=-1");
+  // 被上游安全策略挡了
+  assert.match(describeChoice({ finish_reason: "content_filter", message: {} }), /^finish=content_filter/);
+  // 形态不对也不许炸——日志代码自己把请求搞崩是最坏的结果
+  assert.equal(describeChoice(undefined), "finish=? content=-1 reasoning=-1");
+
+  // content 与 reasoning 都由模型对用户原话的转写构成：长度是安全的，内容不是
+  const echo = describeChoice({
+    finish_reason: "stop",
+    message: { content: "今晚和客户吃饭，包间", reasoning_content: "今晚和客户吃饭" },
+  });
+  assert.ok(!echo.includes("客户"), `用户原话经模型转写后漏进了日志：${echo}`);
+});
+
 test("数字白名单：数给过、单位换了，同样是伪精确", async () => {
   // 白名单只做集合成员判定，而事实包里恒有两个小整数是气温与湿度：
   // tempC 的 0~12 段像小时数，humidity 恒在 0~100 像分钟/厘米。模型不必编新数字，

--- a/src/lib/llmlog.ts
+++ b/src/lib/llmlog.ts
@@ -1,0 +1,198 @@
+// 降级可观测性：让「按设计降级」与「上游坏了」在日志里分得开。
+//
+// 两条 LLM 路由此前有八个 `return 兜底` 的分支，其中只有数字白名单那一条记日志。
+// 于是「线上 DeepSeek 一次都没打通」与「贡献者本地没配 key」在外部完全同形：
+// HTTP 都是 200，body 都带 source: "template" / "heuristic"，Vercel 日志里一片空白。
+// 唯一的判据是人肉点开页面，看眉标写的是「氛寸 · 此刻为你解读」还是「氛寸 · 用香建议」
+//（RecommendationCard.tsx 的三分支）——那不是可观测性，那是运气。
+//
+// 隔壁 /api/context 早有 `console.error("[api/context] upstream error:", …)`：
+// 三条代理付费上游的路由里，只有这两条是哑的。这个文件把那条约定补齐，并且分级。
+//
+// 两条硬约束贯穿全文件：
+// · **绝不写 key**——redact() 在所有 detail 上强制跑一遍，且只取上游的结构化 error.message；
+// · **绝不写用户原话**——detail 的来源被限死在「上游自己的错误消息」「zod 的字段路径」
+//   「被拦下的数字 token」三类，没有任何一条能把 rawText 带进日志。
+
+/** 一次降级的原因。kind 是给 grep 用的，其余字段是给人看的。 */
+export type DegradeReason =
+  | { kind: "no_key" }
+  | { kind: "rate_limited" }
+  | { kind: "budget_exhausted" }
+  | { kind: "upstream_status"; status: number; detail?: string }
+  | { kind: "timeout" }
+  | { kind: "upstream_error"; detail: string }
+  | { kind: "bad_shape"; at: string; detail?: string }
+  | { kind: "guard"; at: string; detail?: string };
+
+export type DegradeKind = DegradeReason["kind"];
+
+/**
+ * 分级的口径只有一句话：**这条线要不要有人去看**。
+ *
+ * error —— 上游坏了。key 无效、余额不足、超时、连不通：不修就永远降级，且用户完全无感。
+ * warn  —— 按设计降级。没配 key（README 明说没有 key 也能跑）、限流、日闸门触顶、
+ *          模型输出不合格被防线拦下：系统正在按预期工作，但频率本身是信号。
+ *
+ * 把 guard 归到 warn 而不是 error，是因为它恰恰证明防线在生效；把 no_key 归到 warn
+ * 而不是 error，是因为本地开发那条路是我们自己承诺支持的。
+ */
+export function levelOf(kind: DegradeKind): "error" | "warn" {
+  return kind === "upstream_status" || kind === "timeout" || kind === "upstream_error"
+    ? "error"
+    : "warn";
+}
+
+/**
+ * 凭据形态的串一律抹掉。
+ *
+ * 不是假想的风险：DeepSeek 的 401 错误体历来把 key 回显在消息里
+ *（"Authentication Fails, Your api key: sk-… is invalid"），而我们要记的正是这条消息。
+ * 第三条规则是兜底——任何 ≥24 位的不透明串都当凭据处理，宁可少读一点上游细节。
+ */
+const SECRETISH: RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{4,}/g, // DeepSeek / OpenAI 形态
+  /\bBearer\s+\S+/gi,
+  /[A-Za-z0-9_-]{24,}/g,
+];
+
+export function redact(s: string): string {
+  let out = s;
+  for (const re of SECRETISH) out = out.replace(re, "***");
+  return out;
+}
+
+/** detail 的硬上限。上游错误消息本来就短；截断是为了防止任何形态的长文本混进日志。 */
+const DETAIL_MAX = 200;
+
+/**
+ * 日志行本身。纯函数、零副作用，导出是为了可测——
+ * 「不许把 key 写进日志」这条约束必须有东西守着，而不是靠 review 时肉眼扫一遍。
+ *
+ * 形态刻意做成 `key=value`，方便在 Vercel 日志里直接按 `降级 upstream_status` 或
+ * `status=401` 过滤，也方便日后接任何一个日志聚合。
+ */
+export function degradeLine(route: string, reason: DegradeReason, ms?: number): string {
+  const parts = [`[${route}] 降级 ${reason.kind}`];
+  if (reason.kind === "upstream_status") parts.push(`status=${reason.status}`);
+  if ("at" in reason) parts.push(`at=${reason.at}`);
+  // 耗时是区分「快速 401」与「上游卡死」的关键——两者的 kind 不同，但排查时先看的是这个数。
+  if (typeof ms === "number" && Number.isFinite(ms)) parts.push(`ms=${Math.round(ms)}`);
+  const detail = "detail" in reason ? reason.detail : undefined;
+  if (detail) parts.push(`detail=${JSON.stringify(redact(detail).slice(0, DETAIL_MAX))}`);
+  return parts.join(" ");
+}
+
+/**
+ * 节流。补日志不能顺手补出一条日志放大路径。
+ *
+ * · no_key / budget_exhausted：**每实例只记一次**。KEY 是模块级常量，日闸门触顶后
+ *   当天余下每一个请求都会再撞一次——重复一万遍不会比第一遍多告诉你任何事。
+ * · rate_limited：60 秒一条。它由客户端行为触发、次数无上限，一个脚本就能把日志刷爆；
+ *   而排查真正需要的是「这段时间里有人在刷」，不是每一次拒绝的流水。
+ * · 其余（上游坏了、防线拦截）：每次都记。它们的**频率**就是信号，压掉就没了。
+ *
+ * 键只由调用方写死的 route 与固定的 kind 拼成，取值有限（路由数 × 8），
+ * 不含任何用户可控的值，所以这个 Map 不会增长——与 ratelimit.ts 那个按 IP 建键的
+ * 不同，这里不需要清理逻辑。
+ */
+const NEVER_AGAIN = Number.POSITIVE_INFINITY;
+const THROTTLE_MS: Record<DegradeKind, number> = {
+  no_key: NEVER_AGAIN,
+  budget_exhausted: NEVER_AGAIN,
+  rate_limited: 60_000,
+  upstream_status: 0,
+  timeout: 0,
+  upstream_error: 0,
+  bad_shape: 0,
+  guard: 0,
+};
+
+const lastLoggedAt = new Map<string, number>();
+
+/** 导出是为了可测：节流策略本身就是这次改动的一半，它不该只在集成里被间接验证。 */
+export function shouldLog(key: string, everyMs: number, now: number = Date.now()): boolean {
+  if (everyMs <= 0) return true;
+  const prev = lastLoggedAt.get(key);
+  if (prev !== undefined && now - prev < everyMs) return false;
+  lastLoggedAt.set(key, now);
+  return true;
+}
+
+export function logDegrade(route: string, reason: DegradeReason, ms?: number): void {
+  if (!shouldLog(`${route}:${reason.kind}`, THROTTLE_MS[reason.kind])) return;
+  const line = degradeLine(route, reason, ms);
+  if (levelOf(reason.kind) === "error") console.error(line);
+  else console.warn(line);
+}
+
+/**
+ * fetch 抛出来的东西 → 一条能定位的原因。纯函数，导出是为了可测。
+ *
+ * 三类要分开，否则「打不通 DeepSeek」和「打通了但它返回了错」会记成同一句话：
+ * · AbortSignal.timeout() 中断 → DOMException("TimeoutError")，这是我们自己设的 12s / 15s；
+ * · 网络层错误 → undici 统一包成 `TypeError: fetch failed`，真正的原因藏在 cause.code
+ *   （ENOTFOUND / ECONNREFUSED / UND_ERR_CONNECT_TIMEOUT …）。只记外层消息等于什么都没记；
+ * · 其余（如 200 但响应体不是 JSON，res.json() 抛 SyntaxError）→ 记名字与消息。
+ *
+ * message 也要过 redact()：它不含用户输入，但 Authorization 头出现在某些底层错误里，
+ * 这条防线的成本是一次正则，没有理由省。
+ */
+export function classifyFetchError(e: unknown): DegradeReason {
+  const err = e as { name?: unknown; message?: unknown; cause?: unknown } | null | undefined;
+  const name = typeof err?.name === "string" ? err.name : "";
+  if (name === "TimeoutError" || name === "AbortError") return { kind: "timeout" };
+  const cause = err?.cause as { code?: unknown } | undefined;
+  const code = typeof cause?.code === "string" ? cause.code : "";
+  const message = typeof err?.message === "string" ? err.message : String(e);
+  return {
+    kind: "upstream_error",
+    detail: code ? `${name || "Error"}/${code}` : `${name || "Error"}: ${message}`,
+  };
+}
+
+/**
+ * 「上游 200 了，但没给出能用的东西」时，把那一次到底发生了什么记下来。
+ *
+ * 这三个字段是分辨以下几种情形的**唯一**依据，而它们彼此的处置完全不同：
+ * · finish=length + reasoning 很长 + content=0 —— 思考型模型把 max_tokens 全花在
+ *   推理上了，正文一个字没轮到。修法是抬 max_tokens 或关思考，不是去查网络；
+ * · finish=stop + content=0 —— 模型真的什么都没说；
+ * · finish=content_filter —— 被上游的安全策略挡了；
+ * · content 有长度但 parse-intent 说 no_json —— 模型没按 json_object 输出。
+ *
+ * 只记**枚举值与字符数**，不记任何一个字。content 与 reasoning 都由模型对用户
+ * 原话的转写构成，长度是安全的，内容不是。
+ */
+export function describeChoice(choice: unknown): string {
+  const c = choice as
+    | { finish_reason?: unknown; message?: { content?: unknown; reasoning_content?: unknown } }
+    | undefined;
+  const finish = typeof c?.finish_reason === "string" ? c.finish_reason : "?";
+  const len = (v: unknown) => (typeof v === "string" ? v.length : -1);
+  return `finish=${finish} content=${len(c?.message?.content)} reasoning=${len(c?.message?.reasoning_content)}`;
+}
+
+/**
+ * 上游错误体里最有诊断价值的那一小段。
+ *
+ * 401 与 402 的区别（key 无效 / 余额不足）只写在这条消息里，而状态码本身分不出
+ * 「key 打错了」和「key 对但欠费」。所以要读，但**只读结构化的那一个字段**：
+ * 非预期形态一律只记长度，不把上游返回的任意文本原样搬进日志——那是唯一可能
+ * 把请求内容回显出来的路径，堵死它比事后截断可靠。
+ */
+export async function readUpstreamError(res: Response): Promise<string> {
+  try {
+    const raw = (await res.text()).slice(0, 1000);
+    try {
+      const j = JSON.parse(raw) as { error?: { message?: unknown }; message?: unknown };
+      const m = j?.error?.message ?? j?.message;
+      if (typeof m === "string") return m;
+    } catch {
+      // 不是 JSON：走下面那条只记长度的路
+    }
+    return `非 JSON 错误体 ${raw.length}B`;
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
## 为什么

2026-08-08 实测生产站 `/api/explain` 与 `/api/parse-intent` 全量走兜底，DeepSeek 一次都没打通。而排查这件事花掉的时间，全部消耗在一个本不该存在的地方：**外部完全看不出来**。

两条路由的八个 `return 兜底` 分支里，只有数字白名单那一条记日志。其余七条——没配 key、限流、日闸门触顶、上游非 200、空文本、语义防线、catch——一律静默返回 200，body 带 `source: "template"` / `"heuristic"`。于是「线上 DeepSeek 一次都没打通」与「贡献者本地没配 key」在日志里是同一件事：什么都没有。唯一的判据是人肉点开页面，看眉标写的是「氛寸 · 此刻为你解读」还是「氛寸 · 用香建议」。

隔壁 `/api/context` 早就有 `console.error("[api/context] upstream error:", …)`。三条代理付费上游的路由里，只有这两条是哑的。

## 改了什么

新增 `src/lib/llmlog.ts`，把降级原因收成八类，两条路由的每一个兜底分支各归其位：

| kind | 级别 | 含义 |
| --- | --- | --- |
| `upstream_status` | error | 上游返回非 2xx，带状态码与上游自己的错误消息 |
| `timeout` | error | 我们自己设的 12s / 15s 到了 |
| `upstream_error` | error | 连不通，带 undici 的 `cause.code` |
| `no_key` | warn | 没配 key（README 承诺的本地模式） |
| `rate_limited` | warn | 单客户端限流 |
| `budget_exhausted` | warn | 日闸门触顶 |
| `bad_shape` | warn | 模型输出不合格（空文本 / 没有 JSON / 坏 JSON / schema 不过） |
| `guard` | warn | 三道防线拦下（avoid 被说软 / good 被说反 / 编造数字） |

分级只有一句话的口径：**这条线要不要有人去看**。`guard` 归到 warn 是因为它恰恰证明防线在生效；`no_key` 归到 warn 是因为「没有 key 也能跑」是 README 写着的承诺——按 error 记就是在训练所有人忽略告警。

每行都带上游那一跳的耗时。一次快速失败（几百毫秒的 401/402）与一次卡到超时（15s）在响应体上完全同形，只有这个数分得开。

## 日志里不许出现什么

两条硬约束，都有用例守着，不靠 review 时肉眼扫：

- **绝不写 key。** DeepSeek 的 401 错误体历来把 key 回显在消息里，而我们要记的正是这条消息。`redact()` 抹掉 `sk-` 形态、`Bearer` 与任何 24 位以上的不透明串，抹完仍留得下 `Authentication Fails` 这半句——这半句才是 401 与 402（key 无效 / 余额不足）的唯一分界，而两者的处置一个是轮换密钥、一个是充值。
- **绝不写用户原话。** `detail` 的来源被限死在三类：上游的结构化 `error.message`、zod 的字段路径（不含 received 值）、被拦下的数字 token。上游错误体只取 `error.message`，非预期形态一律只记长度——那是唯一可能把请求内容回显进日志的路径，堵死它比事后截断可靠。

## 补日志不能顺手补出一条日志放大路径

- `no_key` / `budget_exhausted`：每实例只记一次。`KEY` 是模块级常量，闸门触顶后当天每个请求都会再撞一次，重复一万遍不会比第一遍多告诉你任何事。
- `rate_limited`：60 秒一条。它由客户端行为触发、次数无上限，一个脚本就能把日志刷爆。
- 其余：每次都记，它们的频率就是信号。

节流键只由写死的 route 与固定的 kind 拼成（路由数 × 8），不含任何用户可控值，Map 不会增长——与 `ratelimit.ts` 那个按 IP 建键的不同，这里不需要清理逻辑。

## 两处需要单独看一眼的

- **三条闸门拆开写，求值顺序与短路语义逐字保留。** `allow()` 与 `withinDailyBudget()` 都会**消费计数**，把它们提到 `!KEY` 之前或互换位置都会改变限流与闸门的实际口径。拆开只为把原因记准。
- **`parse-intent` 里模型输出的 `JSON.parse` 单独包起来**，不再落到外层 catch。返回值仍是同一个 fallback，变的是记账：模型写出坏 JSON 是**模型输出不合格**，混进 `upstream_error` 会让告警指向一个没坏的 DeepSeek。

## 一处措辞变更

数字白名单那条并入统一格式。原本的 `[explain] LLM 编造数字被拦截: 6.2` 现在写作 `[explain] 降级 guard at=invented_numbers detail="6.2"`。一个降级面板不该按分支分成两种语法——如果你有按旧字符串建的过滤器，这里要跟着改。

## 验证

- `tsc --noEmit` 干净
- `npm run lint`：0 error / 8 warning（基线不变）
- `npm test`：139 → **145**，全过。新增六条分别守着分级口径、key 不入日志、四种上游坏法分得开、节流不放大、上游错误体只取结构化字段，以及「上游 200 却没给出能用的东西」的四种成因分得开
- `gitleaks`（全历史）：绿。测试里的假密钥一律拼出来而不写成字面量——第一版写成字面量时 `generic-api-key` 当场红了两条，改夹具而不是加豁免
- `npm run build`：13 页

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 实战：这套日志上线后第一次跑，就把找了半天的根因给出来了

预览部署（`dpl_GqJe…`）打了 6 次探针，日志逐行如下：

```
[explain]      降级 bad_shape at=empty_text ms=3824 detail="finish=length content=0 reasoning=1212"
[explain]      降级 guard      at=invented_numbers detail="两下"
[explain]      降级 bad_shape at=empty_text ms=3619 detail="finish=length content=0 reasoning=994"
[parse-intent] 降级 bad_shape at=no_json    ms=3066 detail="finish=length content=0 reasoning=384"
[parse-intent] 降级 bad_shape at=no_json    ms=3132 detail="finish=length content=0 reasoning=436"
[parse-intent] 降级 bad_shape at=no_json    ms=3607 detail="finish=length content=0 reasoning=381"
```

**没有一条是 `upstream_status`、`timeout` 或 `upstream_error`。** key 是好的、余额是够的、网络是通的、模型 ID 是对的——排查这件事之前列的四个候选全部出局，而它们此前都无法证伪。

两条真正的原因，都写在 `detail` 里：

1. **`finish=length content=0 reasoning=1212`** —— `deepseek-v4-flash` 是思考型模型。`max_tokens`（explain 320 / parse-intent 200）被推理 token 吃光，正文一个字都没轮到就撞上了上限。这是主因，且 parse-intent 命中率接近 100%（推理 381–436 字符对 200 tokens 的预算）。
2. **`guard at=invented_numbers detail="两下"`** —— 少数几次推理挤得下、拿到了正文，又被自家的数字防线拦下。事实里写的是半角「2 下」，模型用自然中文复述成「两下」，`findPseudoPreciseCN` 的逐字比对接不上（`CN_NUM` 含「两」、`CN_UNIT` 含「下」）。

第二条要紧的地方在于：**只抬 max_tokens 并不能让功能活过来**，只会把失败从 `bad_shape` 挪到 `guard`。两条都得处理，而这在补日志之前是完全看不见的。

两处修法各自是独立的产品决定（一个动上游参数、一个动反伪精确这条红线），不塞进这个 PR。

