### PR TITLE
docs: 补上版权声明、品牌保留与第三方许可清单

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,10 @@ docs/                   产品方案 · 领域规则手册 · 数据工程 · �
 - **行为准则**：本项目遵循 [Contributor Covenant](.github/CODE_OF_CONDUCT.md)。
 - **安全**：发现漏洞请按 [安全政策](.github/SECURITY.md) 私下报告，勿开公开 Issue。
 - **治理与路线图**：谁说了算、什么不进主线见[贡献指南 · 治理](.github/CONTRIBUTING.md#治理--governance)；路线图在 [产品方案](docs/氛寸-产品方案.md)。
-- **许可证**：源代码以 **AGPL-3.0-only** 授权（见 [LICENSE](LICENSE)）。作为网络服务，若你部署修改版，请依 AGPL §13 向使用者提供对应源码。
-- **数据出处**：`public/data/perfumes.min.json` 派生自 **ledecanteur / Fragrantica** 社区数据，版权归原始来源；本仓库仅作学习与展示用途，**不随代码一并按 AGPL 授权**，如作他用请自行核实来源许可。
+- **版权与许可**：Copyright © 2026 MrBaoboer。源代码以 **AGPL-3.0-only** 授权（见 [LICENSE](LICENSE)）；作为网络服务，若你部署修改版，请依 AGPL §13 向使用者提供对应源码。
+- **品牌**：「氛寸」名称、标识与站点文案不在 AGPL 授权范围内，依 §7(e) 保留；分发或部署修改版请使用你自己的名称与标识。
+- **数据出处**：`public/data/` 派生自 **ledecanteur / Fragrantica** 社区数据，版权归原始来源，**不随代码按 AGPL 授权**；仅供学习与展示，另作他用请自行核实来源许可。
+- **第三方**：随产物分发的字体与依赖见 [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES.md)。
 
 ---
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,20 @@
+# 第三方许可
+
+氛寸自身的源代码以 AGPL-3.0-only 授权（见 [LICENSE](LICENSE)）。下列内容随构建产物一并分发，适用各自的许可。
+
+## 字体
+
+字体文件由 `next/font` 在构建时取回并自托管，随站点分发。
+
+| 字体 | 用途 | 许可 |
+| --- | --- | --- |
+| [Fraunces](https://github.com/undercasetype/Fraunces) | 西文与数字 | SIL Open Font License 1.1 |
+| [Noto Serif SC](https://github.com/notofonts/noto-cjk) | 中文 | SIL Open Font License 1.1 |
+
+## 数据
+
+`public/data/` 下的目录、索引与分片派生自 ledecanteur / Fragrantica 社区数据，版权归原始来源，不随代码按 AGPL 授权。原始数据集不在本仓库分发。
+
+## 依赖
+
+进入浏览器产物的直接依赖均为 MIT：next、react、react-dom、zustand、zod、minisearch，以及生成样式的 tailwindcss。逐包许可见 `package-lock.json`。

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
+  "author": "MrBaoboer (https://github.com/MrBaoboer)",
   "description": "氛寸 — 基于实时情境的个人用香决策 Agent",
   "_engines注释": "运行时版本的唯一事实源。Vercel 明确规定 engines.node 覆盖项目面板里选的版本，写在这里就不必再去对一个仓库外、谁也审计不了的设置。选 24 的理由：Node 22 已于 2025-10-21 进入维护期，24 自 2025-10-28 起是 Active LTS。改这里要连同 .github/workflows/ci.yml 的 node-version 与 devDependencies 的 @types/node 一起改，三者必须同一个大版本；另有三处面向人的复述要跟上——README 的「本地运行」与两份 CONTRIBUTING 的「本地开发」。",
   "engines": {


### PR DESCRIPTION
仓库声明了 AGPL-3.0-only，却没有一处写明版权归属——「保留版权声明」这条义务无从落地。本 PR 补齐三处。

## 改了什么

- **版权**：README 许可一节写明 `Copyright © 2026 MrBaoboer`，`package.json` 补 `author` 字段。
- **品牌**：「氛寸」名称、标识与站点文案按 AGPL §7(e) 排除在授权范围外。AGPL 不含商标条款（Apache-2.0 §6 才有），不单独声明就等于随代码一并授出——任何人可以改代码不改名照常部署。
- **第三方**：新增 `THIRD-PARTY-NOTICES.md`，列出随产物分发的自托管字体（Fraunces / Noto Serif SC，均为 OFL-1.1）、数据出处与运行时依赖。

顺带把数据出处一条改准：派生产物是整个 `public/data/`，不只 `perfumes.min.json`。

## 验证

文档与元数据改动，未触碰任何源码。本地 147/147 用例通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)