### PR TITLE
docs: 逐文件 SPDX 头、AGPL §7 商标条款与 REUSE 门禁

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,13 +60,7 @@ npm run build   # 确保能构建
   git commit -s -m "fix: ……"
   ```
 
-  `-s` 会附上 `Signed-off-by`，表示你按 [Developer Certificate of Origin](https://developercertificate.org/) 声明自己有权提交这份代码。
-
-  这里此前写的是「请对提交做 DCO 签名」，读起来是硬要求，而 CI 里没有任何东西校验它、
-  仓库自己的历史也基本没有签名。**要么让 CI 拦，要么别把它写成规矩**——
-  一条没人执行的规矩只会让第一次提 PR 的人白紧张一次。选后者：这是个人作品集项目，
-  为一条形式性声明加一道会红的门禁不划算。哪天真的需要（比如接受公司来源的贡献），
-  再把它升成硬要求并同时加上校验。
+  `-s` 会附上 `Signed-off-by`，表示你按 [Developer Certificate of Origin](https://developercertificate.org/) 声明自己有权提交这份代码。CI 不校验它——个人作品集项目，为一条形式性声明加一道会红的门禁不划算。
 
 ## Pull Request 流程
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: "1"
 
+  reuse:
+    name: reuse
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # 每个文件都要带版权与许可标注。整站被抄走时能走 GitHub DMCA，前提是「我的声明
+      # 被移除了」拿得出证据；声明只写在根目录 LICENSE 里，复制一个 src/ 就绕开了。
+      # 覆盖规则见 REUSE.toml，数据目录的单独条款见 LICENSES/。
+      - name: REUSE lint
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0
+
   secret-scan:
     name: gitleaks
     runs-on: ubuntu-latest

--- a/LICENSES/AGPL-3.0-only.txt
+++ b/LICENSES/AGPL-3.0-only.txt
@@ -659,32 +659,3 @@ specific requirements.
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-
-================================================================================
-                  ADDITIONAL TERMS UNDER SECTION 7 OF THIS LICENSE
-================================================================================
-
-These terms supplement the GNU Affero General Public License v3.0 above, as
-permitted by section 7(e), and apply to every file in this repository carrying
-the notice `SPDX-License-Identifier: AGPL-3.0-only`.
-
-  Trademarks. No permission is granted, under this License or otherwise, to use
-  the project's names, logos or visual identity — including "氛寸", "FenCun" and
-  "Fēn Cùn" — in original or modified form. If you distribute or deploy a
-  modified version, use your own name and marks.
-
-Files under `public/data/` are not covered by this License. See
-`LICENSES/LicenseRef-fragrance-data.txt`.
-
---------------------------------------------------------------------------------
-
-以下条款依 AGPL-3.0 第 7(e) 条补充于上述许可，适用于本仓库中所有标注
-`SPDX-License-Identifier: AGPL-3.0-only` 的文件。
-
-  商标。本许可不授予对项目名称、标识与视觉形象的任何使用权，包括「氛寸」
-  「FenCun」「Fēn Cùn」，原样或修改后均不授予。分发或部署修改版请使用
-  你自己的名称与标识。
-
-`public/data/` 下的文件不在本许可范围内，见
-`LICENSES/LicenseRef-fragrance-data.txt`。

--- a/LICENSES/LicenseRef-fragrance-data.txt
+++ b/LICENSES/LicenseRef-fragrance-data.txt
@@ -1,0 +1,23 @@
+Fragrance data terms — applies to public/data/**
+
+These files are statistical derivatives of ledecanteur / Fragrantica community
+data: vote counts, averages and category tallies. The build pipeline drops the
+expressive fields at the first step — descriptions, comments, AI summaries and
+similarity carousels are never emitted. The source dataset is not distributed
+in this repository.
+
+Copyright in the underlying data stays with its original sources. This data is
+NOT licensed under AGPL-3.0-only with the rest of the project; it ships here so
+the project can be built and demonstrated. Verify the upstream terms yourself
+before using it for anything else.
+
+---
+
+适用于 public/data/** 的数据条款
+
+这些文件是 ledecanteur / Fragrantica 社区数据的统计派生物：投票计数、均值与
+分类计数。构建管线在第一步就丢弃了描述、评论、AI 摘要与相似轮播等表达性内容，
+原始数据集不在本仓库分发。
+
+底层数据的版权归原始来源，不随代码按 AGPL-3.0-only 授权，随仓库提供仅为让项目
+可构建、可演示。另作他用请自行核实来源许可。

--- a/README.md
+++ b/README.md
@@ -223,14 +223,12 @@ docs/                   产品方案 · 领域规则手册 · 数据工程 · �
 ## 参与 · 许可
 
 - **贡献**：欢迎 Issue 与 PR；动手前请读 [贡献指南](.github/CONTRIBUTING.md)——尤其是四条戒律。
-- **获取帮助**：不知道去哪问？先看 [SUPPORT](.github/SUPPORT.md) 的分流表。
+- **获取帮助**：[SUPPORT](.github/SUPPORT.md) 有分流表。
 - **行为准则**：本项目遵循 [Contributor Covenant](.github/CODE_OF_CONDUCT.md)。
 - **安全**：发现漏洞请按 [安全政策](.github/SECURITY.md) 私下报告，勿开公开 Issue。
 - **治理与路线图**：谁说了算、什么不进主线见[贡献指南 · 治理](.github/CONTRIBUTING.md#治理--governance)；路线图在 [产品方案](docs/氛寸-产品方案.md)。
-- **版权与许可**：Copyright © 2026 MrBaoboer。源代码以 **AGPL-3.0-only** 授权（见 [LICENSE](LICENSE)）；作为网络服务，若你部署修改版，请依 AGPL §13 向使用者提供对应源码。
-- **品牌**：「氛寸」名称、标识与站点文案不在 AGPL 授权范围内，依 §7(e) 保留；分发或部署修改版请使用你自己的名称与标识。
-- **数据出处**：`public/data/` 派生自 **ledecanteur / Fragrantica** 社区数据，版权归原始来源，**不随代码按 AGPL 授权**；仅供学习与展示，另作他用请自行核实来源许可。
-- **第三方**：随产物分发的字体与依赖见 [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES.md)。
+- **许可**：Copyright © 2026 MrBaoboer。源代码 **AGPL-3.0-only**，附 §7 商标条款——「氛寸」的名称与标识不在授权范围内（见 [LICENSE](LICENSE)）。部署修改版请依 §13 向使用者提供对应源码，并换成你自己的名称。
+- **数据与第三方**：`public/data/` 派生自 ledecanteur / Fragrantica 社区数据，条款单列（[LicenseRef-fragrance-data](LICENSES/LicenseRef-fragrance-data.txt)）；随产物分发的字体与依赖见 [THIRD-PARTY-NOTICES](THIRD-PARTY-NOTICES.md)。
 
 ---
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,36 @@
+version = 1
+SPDX-PackageName = "FenCun"
+SPDX-PackageSupplier = "MrBaoboer <mr.baoboer@gmail.com>"
+SPDX-PackageDownloadLocation = "https://github.com/MrBaoboer/FenCun"
+
+# 权威声明是每个源文件顶部的 SPDX 头——复制走一个文件，声明跟着走。
+# 这里再声明一遍，是因为 reuse 用前 2 KB 猜编码，中文注释密集的文件会被判成二进制
+# 直接跳过头部；少了这一段，CI 会对十几个明明有头的文件报缺失。
+[[annotations]]
+path = [
+  "src/**",
+  "scripts/**",
+  "docs/**",
+  ".github/**",
+  ".claude/**",
+  "data/**",
+  "public/*.png",
+  "*.md",
+  "*.ts",
+  "*.mjs",
+  "*.json",
+  ".env.example",
+  ".gitattributes",
+  ".gitignore",
+  ".vercelignore",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 MrBaoboer"
+SPDX-License-Identifier = "AGPL-3.0-only"
+
+# 构建产物派生自社区数据，版权归原始来源，不随代码按 AGPL 授权。
+[[annotations]]
+path = ["public/data/**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = ["2026 MrBaoboer", "Fragrantica community contributors"]
+SPDX-License-Identifier = "LicenseRef-fragrance-data"

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -13,7 +13,7 @@
 
 ## 数据
 
-`public/data/` 下的目录、索引与分片派生自 ledecanteur / Fragrantica 社区数据，版权归原始来源，不随代码按 AGPL 授权。原始数据集不在本仓库分发。
+`public/data/` 下的目录、索引与分片派生自 ledecanteur / Fragrantica 社区数据，条款见 [LicenseRef-fragrance-data](LICENSES/LicenseRef-fragrance-data.txt)。原始数据集不在本仓库分发。
 
 ## 依赖
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 依赖审计门禁：**全树审计 + 逐条具名豁免**。
 //
 // 上一版的门禁是 `npm audit --audit-level=high --omit=dev`。理由当时写得清楚：

--- a/scripts/build-ext.mjs
+++ b/scripts/build-ext.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 全量扩展索引 + 详情分片（零依赖，node 运行）
 // 流式扫描 ledecanteur/perfumes.jsonl，选取：
 //   (people>=50 且 id 不在 Top1500 集合) OR (brand 含 CJK 字符——国货，不设票数门槛)

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 数据构建（零依赖，node 运行）
 // 读取 .scratch/_selected.json（extract 产出）+ data/zh-map/*.json（中文映射）
 // → 产出 public/data/perfumes.min.json（前端只读静态资产）

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";

--- a/scripts/derive.mjs
+++ b/scripts/derive.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 派生纯函数（零依赖，node 运行）
 // 从 build.mjs 抽出的共享派生逻辑：季节拉普拉斯平滑占比、日夜占比、sillage 四档、
 // 风格标签、以及「原始记录 + 中文映射 → Perfume 形状」的完整装配（toPerfume）。

--- a/scripts/extract-terms.mjs
+++ b/scripts/extract-terms.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 数据抽取（零依赖，可直接 node 运行）
 // 两遍流式扫描 ledecanteur/perfumes.jsonl（~509MB）：
 //   Pass1: 按 people>=50 过滤，收集 {id, popularity}

--- a/scripts/og.mjs
+++ b/scripts/og.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 分享卡片与应用图标的生成器
 //
 // 为什么要生成而不是手绘：卡片上的字体、配色、字距必须和站点本身**同源**，

--- a/scripts/shot.mjs
+++ b/scripts/shot.mjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 可复用截图（系统 Chrome 无头）
 // 能 mock 天气 + 冻结时间：既用来展示最文艺的问候（云淡风轻 / 云影入夜），
 // 也用来压测最长文案是否换行 / 挤温度。产出到 .scratch/shots/。

--- a/src/app/api/context/route.ts
+++ b/src/app/api/context/route.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 情境感知：服务端代理和风天气（保护 key），带 30 分钟网格缓存，失败优雅降级
 import { NextRequest, NextResponse } from "next/server";
 import { allow, clientKey, withinWeatherBudget } from "@/lib/ratelimit";

--- a/src/app/api/explain/route.ts
+++ b/src/app/api/explain/route.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 用香解释：DeepSeek 只把「规则已算好的事实」翻译成人话。
 // 决策权在规则引擎，这里只负责表达；严禁编造、严禁伪精确数字；失败降级为模板。
 // 三道代码级防线：① avoid 不许被说软、② good 不许被说反（共用同一条否定语义正则）；

--- a/src/app/api/parse-intent/route.ts
+++ b/src/app/api/parse-intent/route.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 自然语言场景 → 结构化情境补丁（DeepSeek 解析，zod 校验，失败降级关键词启发式）
 // 这是氛寸的差异化：真正理解"去前任婚礼""第一次见投资人"的语义，而非硬套标签
 import { NextRequest, NextResponse } from "next/server";

--- a/src/app/api/route.test.ts
+++ b/src/app/api/route.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 两条 API 路由里**承载红线的降级函数**的单测。
 //
 // 为什么单挑这两个：它们是没有 API key 时唯一会走到的路径——贡献者本地跑（README 明说

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // App Router 错误边界：页面渲染出错时兜底——绝不白屏，绝不让用户以为香柜数据丢了
 import { useEffect } from "react";

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // 根级错误边界。app/error.tsx 只包 page 段，接不住根 layout / AppProvider / SiteChrome
 // 自己抛出的错误——那时落到的是 Next 内置的英文 500 页，连 lang="zh-CN" 都没有，

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2026 MrBaoboer
+SPDX-License-Identifier: AGPL-3.0-only
+Additional terms under AGPL-3.0 §7 — see LICENSE.
+*/
+
 @import "tailwindcss";
 
 /* ─────────────────────────────────────────────────────────────

--- a/src/app/journal/layout.tsx
+++ b/src/app/journal/layout.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 路由段的 layout 天然是 server component，可以导出 metadata，而 page.tsx 保持 "use client"。
 // 四个页面此前共用根 layout 的 title 与 canonical："/"，于是浏览器标签页、书签、
 // 分享卡片全是「氛寸 · 帮你用好香水」，分不清哪个是哪个；og:url 也写死首页，

--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // 香历——被气味标记的生活流水。系统自动生成骨架（哪天·什么天气·喷了什么·感觉如何），
 // 用户零写作负担；留白不谴责：无香的日子也是分寸，绝无「断签」概念。

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import type { Metadata, Viewport } from "next";
 import { Fraunces, Noto_Serif_SC } from "next/font/google";
 import "./globals.css";

--- a/src/app/library/layout.tsx
+++ b/src/app/library/layout.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 路由段的 layout 天然是 server component，可以导出 metadata，而 page.tsx 保持 "use client"。
 // 四个页面此前共用根 layout 的 title 与 canonical："/"，于是浏览器标签页、书签、
 // 分享卡片全是「氛寸 · 帮你用好香水」，分不清哪个是哪个；og:url 也写死首页，

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useStore, type RemovedBundle } from "@/lib/store";

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import type { MetadataRoute } from "next";
 
 // 加到主屏后是 standalone 打开：氛寸是"出门前看一眼"的场景，从主屏一点直达比走浏览器顺手。

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 404：Next 的内置页是英文的「404 / This page could not be found.」，
 // 对一个把分享门面（og / manifest / icon 全自制）当卖点的中文产品，那是一张没被接管的界面。
 //

--- a/src/app/page-meta.ts
+++ b/src/app/page-meta.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import type { Metadata } from "next";
 
 /**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useStore, type AdoptSnapshot } from "@/lib/store";

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 路由段的 layout 天然是 server component，可以导出 metadata，而 page.tsx 保持 "use client"。
 // 四个页面此前共用根 layout 的 title 与 canonical："/"，于是浏览器标签页、书签、
 // 分享卡片全是「氛寸 · 帮你用好香水」，分不清哪个是哪个；og:url 也写死首页，

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useMemo, useRef, useState } from "react";
 import { useStore, type ImportPreview } from "@/lib/store";

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "./layout";
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "./layout";
 

--- a/src/app/theme.test.ts
+++ b/src/app/theme.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 默认主题的守卫。
 //
 // 这是一条产品决定，不是实现细节：**默认恒为明韵（浅色）**，既不按时段自动翻，

--- a/src/components/AppProvider.tsx
+++ b/src/components/AppProvider.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // 全局：一次性加载香水目录 + 解析实时情境（定位→和风天气），跨页共享
 import { createContext, useContext, useEffect, useState, useCallback, useRef } from "react";

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";

--- a/src/components/SiteNotice.tsx
+++ b/src/components/SiteNotice.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // 读盘失败的止损提示。**只在出错时出现**，正常使用永远看不到它。
 //

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useState } from "react";
 

--- a/src/components/library/ManualAdd.tsx
+++ b/src/components/library/ManualAdd.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // 手动记一瓶：搜索兜底的最后防线——1500 主目录和 3.6 万扩展集都没有的香（停产、小众、自调），
 // 也要能进柜、能参与推荐。没有社区数据，就按所选香调的典型情况估计，靠反馈校准。

--- a/src/components/library/PerfumeCard.tsx
+++ b/src/components/library/PerfumeCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { Eyebrow, AccordBar, useDialogA11y } from "@/components/ui";
 import { nameParts, genderLabel, SILLAGE_WORD, durationShort, DISTANCE_LABEL } from "@/lib/format";

--- a/src/components/library/SearchAdd.tsx
+++ b/src/components/library/SearchAdd.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "@/components/AppProvider";

--- a/src/components/library/ShelfCard.tsx
+++ b/src/components/library/ShelfCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { SILLAGE_WORD, durationShort, nameParts } from "@/lib/format";
 import type { Perfume } from "@/lib/types";

--- a/src/components/today/AltList.tsx
+++ b/src/components/today/AltList.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { Eyebrow } from "@/components/ui";
 import { SILLAGE_WORD, nameParts } from "@/lib/format";

--- a/src/components/today/ChangeBottleSheet.tsx
+++ b/src/components/today/ChangeBottleSheet.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useDialogA11y } from "@/components/ui";
 import { SILLAGE_WORD, nameParts } from "@/lib/format";

--- a/src/components/today/ContextBar.tsx
+++ b/src/components/today/ContextBar.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useState } from "react";
 import { useApp } from "@/components/AppProvider";

--- a/src/components/today/EmptyShelf.tsx
+++ b/src/components/today/EmptyShelf.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import Link from "next/link";
 

--- a/src/components/today/FeedbackBar.tsx
+++ b/src/components/today/FeedbackBar.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useState } from "react";
 import { useStore } from "@/lib/store";

--- a/src/components/today/NudgeCard.tsx
+++ b/src/components/today/NudgeCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { Eyebrow } from "@/components/ui";
 import { nameParts } from "@/lib/format";

--- a/src/components/today/OccasionChips.tsx
+++ b/src/components/today/OccasionChips.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useStore } from "@/lib/store";
 import type { Occasion } from "@/lib/types";

--- a/src/components/today/RecommendationCard.tsx
+++ b/src/components/today/RecommendationCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import Link from "next/link";
 import { Eyebrow, EvidenceBar, AccordBar, Stat } from "@/components/ui";

--- a/src/components/today/SceneInput.tsx
+++ b/src/components/today/SceneInput.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useState } from "react";
 import { useStore } from "@/lib/store";

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { ReactNode, RefObject, useEffect, useRef } from "react";
 

--- a/src/lib/catalog-state.ts
+++ b/src/lib/catalog-state.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 目录（主 1500 款 JSON）取数失败时，要不要在页面上告诉用户。
 //
 // 判据原本是 `catalogError && lib.length < userPerfumes.length`——它是为「满柜用户不要被

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 目录与分片的取数层。**刻意不 import MiniSearch**。
 //
 // 这两个函数原本和搜索住在同一个模块（lib/perfumes.ts），而 AppProvider 只需要

--- a/src/lib/demo.test.ts
+++ b/src/lib/demo.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 演示香柜（黄金集）的不变式。
 // 演示态是初次到访者看到的**全部**产品，它出错等于产品出错——所以这些断言与引擎的同级。
 import { test } from "node:test";

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 演示香柜（黄金集）——纯函数层，无副作用、无随机、无 Date.now()：给定 now 必得同一份状态。
 //
 // 为什么需要它：氛寸的第一屏是「你的香柜」，而空柜什么也算不出来。

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 打分/用法/编排引擎单测 —— 确定性纯函数，锁定权重、乘子方向与边界，防重构悄悄改错。
 // 运行：npm test（node --import tsx --test）
 import { test } from "node:test";

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 人话化表达 —— 全部区间/档位，绝不伪精确
 import type { Perfume, Season } from "./types";
 

--- a/src/lib/greeting.ts
+++ b/src/lib/greeting.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 结合天气与时段的简短问候文案（放在天气卡左侧）
 import type { Context } from "./types";
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "@/components/AppProvider";

--- a/src/lib/import-schema.ts
+++ b/src/lib/import-schema.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 备份文件的校验层。**单独一个模块，只为让 zod 离开首屏包**。
 //
 // zod 此前从 store.ts 顶层 import 进来，于是它整个进了客户端共享 chunk：差分构建实测

--- a/src/lib/journal.test.ts
+++ b/src/lib/journal.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 香历纯函数单测：日期键、月网格、族群色点、条目快照、备选差异标签
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/src/lib/journal.ts
+++ b/src/lib/journal.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 香历（穿香日历）与备选对比的纯函数层——可单测，无副作用。
 // 香历是这个产品的记录资产：气味 × 日期 = 记忆索引。系统自动生成骨架，用户零写作负担。
 import type { Perfume, Context, WearEntry } from "./types";

--- a/src/lib/llmlog.ts
+++ b/src/lib/llmlog.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 降级可观测性：让「按设计降级」与「上游坏了」在日志里分得开。
 //
 // 两条 LLM 路由此前有八个 `return 兜底` 的分支，其中只有数字白名单那一条记日志。

--- a/src/lib/nudges.test.ts
+++ b/src/lib/nudges.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 发现型钩子的回归网。它此前长在 hooks.ts 里、被 useApp 的反向 import 关在
 // node --test 够不着的地方——全应用分支最密的一段逻辑只能靠线上发现问题，
 // 历史上「换成你已经拿到的那瓶」就是这么漏出去的。

--- a/src/lib/nudges.ts
+++ b/src/lib/nudges.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 发现型钩子的纯函数层：吃灰提醒(S5) + 天气突变预警(S4)——产品自称的价值重心。
 //
 // 单独成文件有两个理由：

--- a/src/lib/numguard.ts
+++ b/src/lib/numguard.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 数字白名单：反伪精确的代码级防线。
 // 允许出现在 LLM 输出里的数字 = 我们递给它的事实字符串里出现过的数字；
 // 事实之外的任何数字（"留香6.2小时""3.7ml"）都是编造——不辩解，整段退模板。

--- a/src/lib/occasion-priors.ts
+++ b/src/lib/occasion-priors.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 场合先验 —— 刻意与打分引擎分文件存放。
 //
 // ════════════════════════════════════════════════════════════════════════

--- a/src/lib/perfumes.ts
+++ b/src/lib/perfumes.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 中英文搜索（搜名秒加的引擎）。
 // 目录与分片的取数在 lib/catalog.ts —— 拆开是为了让 MiniSearch 只进用得上它的那一页，
 // 见那个文件的说明。

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 简易内存限流（每个 serverless 实例内，无需外部依赖）
 // 用途：挡住单客户端狂刷 / 直接 curl 滥用，保护 DeepSeek 与和风额度。
 // 局限：Vercel 多实例时为"每实例"限流、非全局；若要强一致改用 Upstash Redis 等。

--- a/src/lib/recommend.ts
+++ b/src/lib/recommend.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 推荐编排：打分 → 轮换加权 → 排序 → 主推 + 备选，并为每个候选附上用法/风险/理由/裁决
 import type { Perfume, Context, ScoredPick, Verdict, AvoidCause, Bias, Feedback, Occasion, SuccessConfig } from "./types";
 import { score, sweetDominates, stainProneDominates, dataConfidence, WEATHER_CAUTION, type ScoreParts } from "./scoring";

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 规则打分引擎（确定性，可解释）—— 决策权在这里，LLM 不参与
 import type { Perfume, Context, Feel, Season, Bias } from "./types";
 import { OCCASION_WEIGHTS, FAMILY_DISCOUNT, LOUD_PENALTY } from "./occasion-priors";

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 搜索端到端回归（真实构建产物）：主目录 + 扩展集合并重排后，
 // 国货与长尾必须出现在榜单头部——「观夏搜不到」「闻献被折叠到看不见」两个真实事故的守门员。
 // 依赖 public/data/（构建产物已入库），构建 3.6 万条索引约 1–2 秒，可接受。

--- a/src/lib/season.ts
+++ b/src/lib/season.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 季节 / 体感 / 时段推断 —— 不只看月份，气温同样参与判断
 import type { Season, Feel, Daypart } from "./types";
 

--- a/src/lib/store-wipe.test.ts
+++ b/src/lib/store-wipe.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 盘被抹掉之后的落盘契约。
 //
 // 单开一个文件是必须的：store.test.ts 刻意跑在**没有 window** 的环境里（见那个文件的头注释），

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 本机存储层的契约单测。
 // 注意一个有利的巧合：Node 环境没有 window，persist 的 storage 句柄是 undefined，
 // 于是每次 set 都会在 `.setItem` 上抛错——这正好**稳定复现**了浏览器里

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 "use client";
 // 客户端状态（香水库 + 反馈 + 偏好），持久化到 localStorage
 import { create } from "zustand";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 氛寸 · 核心类型契约
 
 export interface Accord {

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 MrBaoboer
+// SPDX-License-Identifier: AGPL-3.0-only
+// Additional terms under AGPL-3.0 §7 — see LICENSE.
+
 // 用法计算器（规则，产品壁垒层）—— 喷量/部位/距离/留香/风险，全程区间档位
 import type { Perfume, Context, Usage, Bias } from "./types";
 import { durationHint, SEASON_NAME } from "./format";


### PR DESCRIPTION
## 这个 PR 做了什么 / What does this PR do

把版权声明从「只写在根目录」补成「跟着每个文件走」，并把商标保留放到许可正文里。

#44 补上了 Copyright 与 §7(e) 品牌保留，但两处放在了 README。实际效果有限：

- **声明不跟着文件走。** 复制走一个 `src/` 目录就绕开了全部声明，而 GitHub DMCA 的举证前提正是「我的声明被移除了」。各类 license scanner（ScanCode、FOSSA、Snyk）也只认文件头。
- **§7 附加条款位置不对。** AGPL §7 要求附加条款写在源文件里，或给出去处；README 不满足这一条。

改动：

- 77 个源文件补 SPDX 头：版权、许可，以及附加条款的去处
- `LICENSE` 追加 §7 附加条款（中英双语），商标保留从 README 移进许可正文
- `LICENSES/`：AGPL-3.0-only 全文，以及 `public/data/` 的单独条款 `LicenseRef-fragrance-data`
- `REUSE.toml` 声明文档、资产与配置的归属。reuse 用前 2 KB 猜编码，中文注释密集的文件会被判成二进制、跳过头部，所以源码目录在这里也声明一遍
- CI 新增 `reuse` job，action 按 SHA 固定
- README 许可段与 THIRD-PARTY-NOTICES 去掉与 LICENSE 重复的条款正文，只留指路
- CONTRIBUTING 的 DCO 一节删掉对旧措辞的复盘，留做法与「CI 不校验」

关联 Issue / Related issue: 无

## 改动类型 / Type of change

- [ ] 🐛 Bug 修复 / Bug fix
- [ ] ✨ 新能力 / New feature
- [x] 📝 文档 / Docs
- [ ] ♻️ 重构 / Refactor
- [ ] 🎨 文案或 UI / Copy or UI

## 如何验证 / How verified

没有行为改动，全部是文件头注释与许可文本。

```
reuse lint      189/189 合规
npm run lint    0 errors（8 条既有 react-hooks warning 未变）
npm test        147 passed
npm run build   13 页全出，CSS 产物 96 KB（Tailwind 正常编译）
```

`"use client"` 前置注释与 `globals.css` 的 `@import "tailwindcss"` 前置注释都验过：构建产物正常。

## 检查清单 / Checklist

- [x] 守住四条戒律：不伪精确 · 不过度设计 · 轻冷启动 · 有反馈闭环
- [x] `npm run lint` 通过 / passes
- [x] `npm test` 通过 / passes
- [x] `npm run build` 通过 / passes
- [ ] （建议，非必需）提交已 DCO 签名 / signed off (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
